### PR TITLE
fix: avoid duplicate initial appearance announcements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-13
+
+- Prevented initial or unchanged trait callbacks from repeating the appearance
+  update and VoiceOver announcement, with executable transition-decision tests.
+
 ## 2026-06-12
 
 - Added a tvOS XCTest target and shared scheme covering light, dark, and

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The project uses Swift 5 and has no third-party package dependencies.
 - Switch the simulator or device to Dark appearance, then confirm the centered
   label reads `Dark Mode` with a black background. With VoiceOver enabled,
   confirm the updated appearance state is announced after the switch.
+- Confirm initial presentation and repeated callbacks for the same appearance
+  do not repeat the VoiceOver announcement.
 - If the trait collection reports an unspecified style, confirm the fallback
   label reads `Automatic Mode` on a dark gray background.
 
@@ -128,6 +130,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   display-only appearance label guard.
 - See `docs/plans/2026-06-10-appearance-announcement.md` for trait-change
   VoiceOver announcement coverage.
+- See `docs/plans/2026-06-13-initial-appearance-announcement.md` for initial and
+  unchanged callback suppression.
 - See `docs/plans/2026-06-09-app-delegate-launch-options.md` for the historical
   Swift 3 app delegate launch-options correction.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions static

--- a/VISION.md
+++ b/VISION.md
@@ -23,6 +23,7 @@ Priority:
 - Keep appearance labels display-only and non-interactive
 - Keep appearance labels described for assistive technologies
 - Announce live appearance changes to assistive technologies
+- Avoid duplicate announcements during initial or unchanged appearance callbacks
 - Keep the root appearance view identifiable for simulator/UI verification
 - Keep appearance text scaled within the tvOS viewport
 - Keep appearance text bounded inside the tvOS viewport

--- a/docs/plans/2026-06-13-initial-appearance-announcement.md
+++ b/docs/plans/2026-06-13-initial-appearance-announcement.md
@@ -1,0 +1,109 @@
+---
+title: "fix: Avoid duplicate initial appearance announcements"
+type: fix
+date: 2026-06-13
+---
+
+# Avoid Duplicate Initial Appearance Announcements
+
+## Status: Completed
+
+## Context
+
+`viewDidLoad` already applies the initial tvOS appearance. The subsequent trait
+callback currently treats a missing previous trait collection as a style
+change, which can repeat that update and post an unnecessary accessibility
+announcement during initial presentation.
+
+## Requirements
+
+- R1. Keep initial appearance rendering in `viewDidLoad`.
+- R2. Announce only when a known previous interface style differs from the new
+  style.
+- R3. Skip announcements for a missing previous style or an unchanged style.
+- R4. Cover nil, unchanged, light-to-dark, and dark-to-light decisions with
+  executable XCTest cases.
+- R5. Preserve existing appearance colors, labels, identifiers, and VoiceOver
+  announcement ordering.
+
+## Scope Boundaries
+
+This change adjusts only announcement eligibility. It does not replace
+`traitCollectionDidChange`, alter the visual presentation, add UI automation,
+or change the minimum tvOS deployment target.
+
+## Implementation Units
+
+### U1. Extract the Announcement Predicate
+
+- **Goal:** Make initial and redundant callback behavior explicit and testable.
+- **Files:** `tvos-darkmode/ViewController.swift`
+- **Approach:** Add a pure appearance-change predicate that requires a previous
+  style and compares it with the current style. Use it as the trait callback's
+  guard before updating and announcing.
+- **Test scenarios:** Missing previous style returns false; equal styles return
+  false; light-to-dark and dark-to-light return true.
+- **Verification:** The trait callback still updates before posting the
+  accessibility announcement for real changes.
+
+### U2. Add Executable and Static Contracts
+
+- **Goal:** Prevent duplicate initial announcements from returning.
+- **Files:** `tvos-darkmodeTests/AppearancePresentationTests.swift`,
+  `scripts/check_tvos_contracts.py`
+- **Approach:** Add deterministic XCTest cases for the pure predicate and
+  require the predicate, nil guard semantics, tests, and ordering statically.
+- **Test scenarios:** Mutations that accept nil, accept equal styles, reject a
+  real transition, remove a test, or bypass the predicate are rejected.
+- **Verification:** Static checks pass locally; hosted tvOS XCTest remains the
+  executable authority.
+
+### U3. Record the Accessibility Contract
+
+- **Goal:** Document the completed behavior and actual verification evidence.
+- **Files:** `README.md`, `VISION.md`, `CHANGES.md`,
+  `docs/plans/2026-06-13-initial-appearance-announcement.md`
+- **Approach:** Explain that initial state is rendered once and only real style
+  transitions generate announcements.
+- **Test expectation:** Documentation is enforced by the completed-plan
+  checker; no separate runtime behavior is introduced.
+- **Verification:** The completed plan distinguishes local static validation
+  from hosted Xcode execution.
+
+## Risks
+
+- A predicate that rejects all transitions would silence useful announcements.
+- Moving the accessibility post before the visual update would announce stale
+  state.
+- Local Linux validation cannot execute UIKit or XCTest.
+
+## Assumptions
+
+- `viewDidLoad` remains the single initial appearance render path.
+- The existing macOS 15/Xcode 16.4 hosted job provides tvOS 18.5 XCTest
+  execution for the successor PR.
+
+## Work Completed
+
+- Added a pure announcement predicate that requires a known previous style and
+  a real style transition.
+- Routed `traitCollectionDidChange` through the predicate before updating or
+  posting the accessibility announcement.
+- Added executable nil, unchanged, light-to-dark, and dark-to-light XCTest
+  cases.
+- Extended portable contracts for the predicate, callback use, test names, and
+  update-before-announcement ordering.
+- Updated manual verification, vision, and change documentation.
+
+## Verification
+
+- `make check` on Python 3.12.8 passed all eight portable contract groups
+- Local XCTest and app build were truthfully skipped because `xcodebuild` is not
+  available on this Linux host
+- Five hostile mutations covering nil, equality, transition, callback, and
+  executable-test contracts were rejected
+- `python -m py_compile scripts/check_tvos_contracts.py`
+- `git diff --check`
+
+The successor PR must provide the canonical macOS 15/Xcode 16.4 tvOS 18.5
+XCTest result before this change is eligible to merge.

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -18,6 +18,7 @@ CI_PLAN = DOCS_PLANS / "2026-06-10-ci-baseline.md"
 MODERN_XCODE_PLAN = DOCS_PLANS / "2026-06-10-modern-xcode-build.md"
 EXECUTABLE_TEST_PLAN = DOCS_PLANS / "2026-06-12-executable-appearance-tests.md"
 CODEQL_PLAN = DOCS_PLANS / "2026-06-12-codeql-manual-swift-build.md"
+INITIAL_ANNOUNCEMENT_PLAN = DOCS_PLANS / "2026-06-13-initial-appearance-announcement.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 CODEQL_WORKFLOW = ROOT / ".github" / "workflows" / "codeql.yml"
 SHARED_SCHEME = ROOT / "tvos-darkmode.xcodeproj" / "xcshareddata" / "xcschemes" / "tvos-darkmode.xcscheme"
@@ -166,6 +167,10 @@ def check_docs_plans():
     require(
         CODEQL_PLAN.exists(),
         "docs/plans/2026-06-12-codeql-manual-swift-build.md is missing",
+    )
+    require(
+        INITIAL_ANNOUNCEMENT_PLAN.exists(),
+        "docs/plans/2026-06-13-initial-appearance-announcement.md is missing",
     )
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     require(plans, "docs/plans must contain at least one completed plan")
@@ -324,6 +329,16 @@ def check_visible_appearance_state():
         "appearance state must update before its accessibility announcement",
     )
     require(
+        "static func shouldAnnounceChange(" in view_controller
+        and "guard let previousStyle = previousStyle else" in view_controller
+        and "return previousStyle != currentStyle" in view_controller,
+        "appearance announcements must require a known, changed previous style",
+    )
+    require(
+        "AppearancePresentation.shouldAnnounceChange(" in trait_change.group(0),
+        "trait changes must use the tested announcement predicate",
+    )
+    require(
         "traitCollection.responds(to:" not in view_controller,
         "tvOS 12 appearance handling must not rely on Objective-C selector checks",
     )
@@ -380,6 +395,10 @@ def check_executable_tests():
         "testDarkAppearanceUsesWhiteTextOnBlack",
         "testLightAppearanceUsesBlackTextOnWhite",
         "testUnspecifiedAppearanceUsesAutomaticFallback",
+        "testMissingPreviousStyleDoesNotAnnounce",
+        "testUnchangedStyleDoesNotAnnounce",
+        "testLightToDarkStyleChangeAnnounces",
+        "testDarkToLightStyleChangeAnnounces",
         'XCTAssertEqual(presentation.text, "Dark Mode")',
         'XCTAssertEqual(presentation.text, "Light Mode")',
         'XCTAssertEqual(presentation.text, "Automatic Mode")',

--- a/tvos-darkmode/ViewController.swift
+++ b/tvos-darkmode/ViewController.swift
@@ -31,6 +31,16 @@ struct AppearancePresentation {
             )
         }
     }
+
+    static func shouldAnnounceChange(
+        from previousStyle: UIUserInterfaceStyle?,
+        to currentStyle: UIUserInterfaceStyle
+    ) -> Bool {
+        guard let previousStyle = previousStyle else {
+            return false
+        }
+        return previousStyle != currentStyle
+    }
 }
 
 final class ViewController: UIViewController {
@@ -47,7 +57,10 @@ final class ViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        guard traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle else {
+        guard AppearancePresentation.shouldAnnounceChange(
+            from: previousTraitCollection?.userInterfaceStyle,
+            to: traitCollection.userInterfaceStyle
+        ) else {
             return
         }
 

--- a/tvos-darkmodeTests/AppearancePresentationTests.swift
+++ b/tvos-darkmodeTests/AppearancePresentationTests.swift
@@ -26,4 +26,28 @@ final class AppearancePresentationTests: XCTestCase {
         XCTAssertEqual(presentation.backgroundColor, .darkGray)
         XCTAssertEqual(presentation.textColor, .white)
     }
+
+    func testMissingPreviousStyleDoesNotAnnounce() {
+        XCTAssertFalse(
+            AppearancePresentation.shouldAnnounceChange(from: nil, to: .dark)
+        )
+    }
+
+    func testUnchangedStyleDoesNotAnnounce() {
+        XCTAssertFalse(
+            AppearancePresentation.shouldAnnounceChange(from: .dark, to: .dark)
+        )
+    }
+
+    func testLightToDarkStyleChangeAnnounces() {
+        XCTAssertTrue(
+            AppearancePresentation.shouldAnnounceChange(from: .light, to: .dark)
+        )
+    }
+
+    func testDarkToLightStyleChangeAnnounces() {
+        XCTAssertTrue(
+            AppearancePresentation.shouldAnnounceChange(from: .dark, to: .light)
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Initial presentation and unchanged tvOS trait callbacks no longer repeat the appearance update or post a redundant VoiceOver announcement. Real light-to-dark and dark-to-light transitions still update the visible and accessibility state first, then announce the new mode.

## Baseline

The appearance callback could repeat its initial update and announcement even when no meaningful interface-style transition occurred. That produced redundant VoiceOver output during initial presentation and unchanged trait callbacks.

## Improvements

- express the announcement decision as a pure, executable predicate
- suppress duplicate updates and announcements for nil or unchanged transitions
- preserve announcements for both light-to-dark and dark-to-light transitions
- keep visible and accessibility state updates ahead of VoiceOver announcements
- protect callback use, test presence, and update-before-announcement ordering with portable contracts

## Validation

- `make check` completed across eight portable contract groups with the documented local Xcode skip
- five hostile announcement-decision mutations were rejected
- nil, unchanged, and bidirectional transition behavior is covered
- Python checker compilation and `git diff --check` succeeded
- hosted static contracts and tvOS 18.5 XCTest succeeded on macOS 15 with Xcode 16.4
- hosted CodeQL script and Swift analysis succeeded

## Risk

- Local Xcode is unavailable, so the pinned hosted macOS 15/Xcode 16.4 tvOS 18.5 job remains the executable platform authority.
- VoiceOver announcement behavior depends on preserving the update-before-announcement ordering during future callback changes.
- The predicate intentionally suppresses nil and unchanged transitions; future trait-handling changes must retain that distinction.

## Follow-Ups

- Preserve nil, unchanged, and bidirectional predicate coverage when extending appearance handling.
- Keep hosted tvOS XCTest and Swift analysis required for future callback changes.
- Verify VoiceOver behavior manually on representative tvOS hardware when available.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
