### PR TITLE
Exercise tvOS controller appearance rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Added controller-level tvOS XCTest for dark and light rendered hierarchy,
+  colors, text, and accessibility identifiers without exposing private state.
 - Prevented initial or unchanged trait callbacks from repeating the appearance
   update and VoiceOver announcement, with executable transition-decision tests.
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ The project uses Swift 5 and has no third-party package dependencies.
   contract checks. It also enforces Swift 5, the tvOS 12 deployment floor,
   modern UIKit launch APIs, and hosted Xcode compilation.
 - Static checks also require completed canonical plans under `docs/plans`.
-- `make test` executes three appearance-presentation tests on the Apple TV 4K
-  (3rd generation) tvOS 18.5 simulator when Xcode is available and reports an
-  explicit skip on non-macOS hosts.
+- `make test` executes resolver, announcement, and dark/light controller
+  hierarchy tests on the Apple TV 4K (3rd generation) tvOS 18.5 simulator when
+  Xcode is available and reports an explicit skip on non-macOS hosts.
 - `make build` compiles the Debug app for the tvOS simulator when Xcode is
   available and reports an explicit skip on non-macOS hosts.
 
@@ -140,6 +140,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   Xcode build baseline.
 - See `docs/plans/2026-06-12-executable-appearance-tests.md` for the executable
   XCTest baseline.
+- See `docs/plans/2026-06-13-controller-rendering-tests.md` for controller-level
+  dark/light hierarchy assertions and their non-visual boundary.
 - See `docs/plans/2026-06-12-codeql-manual-swift-build.md` for the explicit
   Swift CodeQL build baseline.
 

--- a/VISION.md
+++ b/VISION.md
@@ -31,6 +31,7 @@ Priority:
 - Keep app delegate signatures aligned with the checked-in Swift version
 - Keep the Swift 5 and tvOS 12 project baseline buildable with Xcode 16.4
 - Keep light, dark, and fallback appearance mapping covered by hosted XCTest
+- Keep dark and light controller hierarchy rendering covered by hosted XCTest
 - Keep completed maintenance plans under `docs/plans`
 - Keep GitHub Actions running both portable contracts and hosted XCTest
 

--- a/docs/plans/2026-06-13-controller-rendering-tests.md
+++ b/docs/plans/2026-06-13-controller-rendering-tests.md
@@ -6,7 +6,7 @@ date: 2026-06-13
 
 # Controller Appearance Rendering Tests
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -16,8 +16,8 @@ resolved state into the real label, root view, and accessibility identifiers.
 
 ## Requirements
 
-- R1. Instantiate `ViewController` under dark and light interface-style
-  overrides and load its view hierarchy.
+- R1. Instantiate `ViewController` under tvOS-compatible parent trait
+  overrides for dark and light styles and load its view hierarchy.
 - R2. Verify the actual appearance label text, text color, accessibility label,
   and accessibility identifier for both styles.
 - R3. Verify the root view background color and accessibility identifier.
@@ -57,8 +57,11 @@ resolved state into the real label, root view, and accessibility identifiers.
 
 ## Verification
 
-- `make check` on Linux with truthful XCTest/app-build skips
-- Hosted macOS 15, Xcode 16.4, tvOS 18.5 XCTest on the exact pushed head
-- Hostile mutations removing either style test or hierarchy assertion
+- `make check` on Python 3.12.8 passed all portable contracts with truthful
+  XCTest and app-build skips because Xcode is unavailable on this Linux host.
+- Hostile mutations removing either style test or hierarchy assertion were
+  rejected.
 - Python compilation, structured-file parsing, `git diff --check`, and focused
-  secret/artifact review
+  secret/artifact review passed.
+- Hosted macOS 15, Xcode 16.4, tvOS 18.5 XCTest on the exact pushed head remains
+  the required executable merge gate.

--- a/docs/plans/2026-06-13-controller-rendering-tests.md
+++ b/docs/plans/2026-06-13-controller-rendering-tests.md
@@ -1,0 +1,64 @@
+---
+title: "test: Exercise tvOS controller appearance rendering"
+type: test
+date: 2026-06-13
+---
+
+# Controller Appearance Rendering Tests
+
+## Status: In Progress
+
+## Context
+
+Existing XCTest covers the pure appearance resolver and announcement predicate,
+but does not instantiate `ViewController` or prove that `viewDidLoad` wires the
+resolved state into the real label, root view, and accessibility identifiers.
+
+## Requirements
+
+- R1. Instantiate `ViewController` under dark and light interface-style
+  overrides and load its view hierarchy.
+- R2. Verify the actual appearance label text, text color, accessibility label,
+  and accessibility identifier for both styles.
+- R3. Verify the root view background color and accessibility identifier.
+- R4. Keep production visibility encapsulated; tests must locate views through
+  public UIKit hierarchy and accessibility contracts rather than new test-only
+  APIs.
+- R5. Preserve resolver, announcement, layout, workflow, project, and signing
+  behavior.
+- R6. Portable contracts must require both controller tests and their key
+  hierarchy assertions; hosted tvOS XCTest remains the executable authority.
+
+## Scope Boundaries
+
+- Do not add a UI-test target, snapshots, app launch automation, or signing.
+- Do not alter runtime appearance behavior or expose private controller state.
+- Do not claim visual pixel fidelity or VoiceOver device verification.
+
+## Implementation Units
+
+### U1. Add controller-level XCTest
+
+- **Files:** `tvos-darkmodeTests/AppearancePresentationTests.swift`
+- Add dark and light tests that apply an override, call `loadViewIfNeeded`, find
+  the label by accessibility identifier, and assert rendered UIKit state.
+
+### U2. Preserve portable contracts
+
+- **Files:** `scripts/check_tvos_contracts.py`
+- Require both test names, hierarchy lookup, style overrides, view loading,
+  rendered colors/text, and accessibility assertions.
+
+### U3. Record the verification boundary
+
+- **Files:** `README.md`, `VISION.md`, `CHANGES.md`
+- Distinguish controller rendering coverage from full app-launch, visual, and
+  assistive-technology verification.
+
+## Verification
+
+- `make check` on Linux with truthful XCTest/app-build skips
+- Hosted macOS 15, Xcode 16.4, tvOS 18.5 XCTest on the exact pushed head
+- Hostile mutations removing either style test or hierarchy assertion
+- Python compilation, structured-file parsing, `git diff --check`, and focused
+  secret/artifact review

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -399,9 +399,23 @@ def check_executable_tests():
         "testUnchangedStyleDoesNotAnnounce",
         "testLightToDarkStyleChangeAnnounces",
         "testDarkToLightStyleChangeAnnounces",
+        "testDarkControllerRendersAppearanceHierarchy",
+        "testLightControllerRendersAppearanceHierarchy",
         'XCTAssertEqual(presentation.text, "Dark Mode")',
         'XCTAssertEqual(presentation.text, "Light Mode")',
         'XCTAssertEqual(presentation.text, "Automatic Mode")',
+        "container.addChild(controller)",
+        "container.setOverrideTraitCollection(",
+        "UITraitCollection(userInterfaceStyle: style)",
+        "controller.loadViewIfNeeded()",
+        "XCTAssertEqual(controller.traitCollection.userInterfaceStyle, style)",
+        'XCTAssertEqual(controller.view.accessibilityIdentifier, "appearance-state-root-view")',
+        ".compactMap { $0 as? UILabel }",
+        '.first { $0.accessibilityIdentifier == "appearance-state-label" }',
+        "XCTAssertEqual(label?.text, text)",
+        "XCTAssertEqual(label?.accessibilityLabel, text)",
+        "XCTAssertEqual(label?.textColor, textColor)",
+        "XCTAssertEqual(controller.view.backgroundColor, backgroundColor)",
     ):
         require(fragment in tests, f"XCTest coverage is missing: {fragment}")
     require("XCTFail" not in tests, "XCTest coverage must not contain placeholder failures")

--- a/tvos-darkmodeTests/AppearancePresentationTests.swift
+++ b/tvos-darkmodeTests/AppearancePresentationTests.swift
@@ -50,4 +50,50 @@ final class AppearancePresentationTests: XCTestCase {
             AppearancePresentation.shouldAnnounceChange(from: .dark, to: .light)
         )
     }
+
+    func testDarkControllerRendersAppearanceHierarchy() {
+        assertController(
+            style: .dark,
+            text: "Dark Mode",
+            backgroundColor: .black,
+            textColor: .white
+        )
+    }
+
+    func testLightControllerRendersAppearanceHierarchy() {
+        assertController(
+            style: .light,
+            text: "Light Mode",
+            backgroundColor: .white,
+            textColor: .black
+        )
+    }
+
+    private func assertController(
+        style: UIUserInterfaceStyle,
+        text: String,
+        backgroundColor: UIColor,
+        textColor: UIColor
+    ) {
+        let container = UIViewController()
+        let controller = ViewController()
+        container.addChild(controller)
+        container.setOverrideTraitCollection(
+            UITraitCollection(userInterfaceStyle: style),
+            forChild: controller
+        )
+        controller.loadViewIfNeeded()
+
+        XCTAssertEqual(controller.traitCollection.userInterfaceStyle, style)
+        XCTAssertEqual(controller.view.accessibilityIdentifier, "appearance-state-root-view")
+        let label = controller.view.subviews
+            .compactMap { $0 as? UILabel }
+            .first { $0.accessibilityIdentifier == "appearance-state-label" }
+
+        XCTAssertNotNil(label)
+        XCTAssertEqual(label?.text, text)
+        XCTAssertEqual(label?.accessibilityLabel, text)
+        XCTAssertEqual(label?.textColor, textColor)
+        XCTAssertEqual(controller.view.backgroundColor, backgroundColor)
+    }
 }


### PR DESCRIPTION
## Summary

- instantiate the real ViewController under tvOS-compatible dark and light trait overrides
- verify rendered label text/colors, root background, and accessibility identifiers through the UIKit hierarchy

## Baseline

- portable contracts did not exercise the real ViewController under both tvOS appearance traits
- rendered UIKit hierarchy state lacked focused assertions for text, colors, background, and accessibility identifiers

## Improvements

- preserve private production state and require the controller assertions in portable contracts

## Validation

- `make check` passed all eight portable contract groups
- local XCTest and app build truthfully skipped because xcodebuild is unavailable on Linux
- structured plist/storyboard/project/scheme/assets/workflow parsing passed
- 10 hostile controller-test mutations were rejected
- `git diff --check` and focused secret/artifact review passed

## Risk

- local Linux validation cannot run XCTest or build the tvOS application because xcodebuild is unavailable
- hosted macOS 15/Xcode 16.4 tvOS 18.5 XCTest is required before merge
- this is a stacked pull request based on #3 (`lfg/tvos-initial-announcement-20260613`), so its merge order must be preserved

## Follow-Ups

Base: #3 (`lfg/tvos-initial-announcement-20260613`). Review and merge after the base PR. Hosted macOS 15/Xcode 16.4 tvOS 18.5 XCTest is required before merge.
