### PR TITLE
test: cover controller trait transitions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Added hosted controller-level coverage for dark-to-light and light-to-dark
+  trait transitions, including visible and accessible appearance state.
 - Added controller-level tvOS XCTest for dark and light rendered hierarchy,
   colors, text, and accessibility identifiers without exposing private state.
 - Prevented initial or unchanged trait callbacks from repeating the appearance

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ The project uses Swift 5 and has no third-party package dependencies.
   contract checks. It also enforces Swift 5, the tvOS 12 deployment floor,
   modern UIKit launch APIs, and hosted Xcode compilation.
 - Static checks also require completed canonical plans under `docs/plans`.
-- `make test` executes resolver, announcement, and dark/light controller
-  hierarchy tests on the Apple TV 4K (3rd generation) tvOS 18.5 simulator when
-  Xcode is available and reports an explicit skip on non-macOS hosts.
+- `make test` executes resolver, announcement, initial controller hierarchy,
+  and bidirectional trait-transition rendering tests on the Apple TV 4K (3rd
+  generation) tvOS 18.5 simulator when Xcode is available and reports an
+  explicit skip on non-macOS hosts.
 - `make build` compiles the Debug app for the tvOS simulator when Xcode is
   available and reports an explicit skip on non-macOS hosts.
 
@@ -142,6 +143,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   XCTest baseline.
 - See `docs/plans/2026-06-13-controller-rendering-tests.md` for controller-level
   dark/light hierarchy assertions and their non-visual boundary.
+- See `docs/plans/2026-06-13-controller-trait-transition-rendering.md` for
+  loaded-controller dark/light transition coverage.
 - See `docs/plans/2026-06-12-codeql-manual-swift-build.md` for the explicit
   Swift CodeQL build baseline.
 

--- a/VISION.md
+++ b/VISION.md
@@ -32,6 +32,8 @@ Priority:
 - Keep the Swift 5 and tvOS 12 project baseline buildable with Xcode 16.4
 - Keep light, dark, and fallback appearance mapping covered by hosted XCTest
 - Keep dark and light controller hierarchy rendering covered by hosted XCTest
+- Keep loaded-controller dark-to-light and light-to-dark rendering covered by
+  hosted XCTest
 - Keep completed maintenance plans under `docs/plans`
 - Keep GitHub Actions running both portable contracts and hosted XCTest
 

--- a/docs/plans/2026-06-13-controller-trait-transition-rendering.md
+++ b/docs/plans/2026-06-13-controller-trait-transition-rendering.md
@@ -1,0 +1,67 @@
+# Controller Trait Transition Rendering
+
+## Status: Planned
+
+## Context
+
+Hosted XCTest covers the pure appearance resolver and the controller's initial
+dark and light hierarchy. It does not directly prove that an already-loaded
+controller updates its visible and accessible state when tvOS changes the
+effective interface style.
+
+## Priority
+
+Add mutation-sensitive controller tests for both dark-to-light and
+light-to-dark transitions before extending the sample further. This keeps the
+sample's central trait-change behavior executable instead of relying only on
+source contracts and manual simulator checks.
+
+## Requirements
+
+- R1. Load the real `ViewController` under a known initial interface style.
+- R2. Change the child controller's effective trait collection after loading.
+- R3. Verify the label text, accessibility label, foreground color, and root
+  background color after a dark-to-light transition.
+- R4. Verify the same visible and accessible state after a light-to-dark
+  transition.
+- R5. Extend the static checker so removal of either executable transition
+  scenario fails `make check` on non-macOS hosts.
+- R6. Preserve production appearance mapping and announcement behavior.
+
+## Implementation Units
+
+### Executable controller transitions
+
+**Files:** `tvos-darkmodeTests/AppearancePresentationTests.swift`
+
+Reuse the existing controller containment and label lookup pattern. Add
+bidirectional scenarios that load the controller under one style, apply the
+other style through the parent override, deliver the prior trait collection,
+and assert the final presentation hierarchy.
+
+### Portable test contracts and maintenance record
+
+**Files:** `scripts/check_tvos_contracts.py`, `README.md`, `VISION.md`,
+`CHANGES.md`, `docs/plans/2026-06-13-controller-trait-transition-rendering.md`
+
+Require both transition test names and their before/after style pairings in the
+portable contract gate. Document the executable transition coverage and record
+the completed validation evidence.
+
+## Verification Plan
+
+- portable static contracts through `make check`
+- hosted tvOS XCTest for both controller transition directions
+- focused hostile mutations for missing transition tests, reversed styles,
+  weakened hierarchy assertions, documentation drift, and stale plan status
+- project/XML/plist/asset parsing, intended-path, generated-artifact,
+  whitespace, and secret-pattern audits
+
+## Scope Boundaries
+
+- Do not change production rendering, appearance colors, accessibility copy,
+  or announcement policy.
+- Do not raise the tvOS deployment target or replace
+  `traitCollectionDidChange` in this change.
+- Do not add UI-test infrastructure, screenshots, network behavior, or third-
+  party dependencies.

--- a/docs/plans/2026-06-13-controller-trait-transition-rendering.md
+++ b/docs/plans/2026-06-13-controller-trait-transition-rendering.md
@@ -1,6 +1,6 @@
 # Controller Trait Transition Rendering
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -65,3 +65,26 @@ the completed validation evidence.
   `traitCollectionDidChange` in this change.
 - Do not add UI-test infrastructure, screenshots, network behavior, or third-
   party dependencies.
+
+## Work Completed
+
+- Added dark-to-light and light-to-dark tests around the real loaded controller
+  hierarchy.
+- Reused one hierarchy assertion for effective style, visible text,
+  accessibility text, foreground color, and root background color.
+- Extended the portable checker and maintenance docs to preserve both
+  transition directions and their initial/final style pairings.
+
+## Verification
+
+- `make check` passed the project, plist, asset, workflow, plan, source, and
+  executable-test contracts under a 60-second hard timeout. On this Linux host,
+  the Makefile truthfully reported that tvOS XCTest and build execution were
+  skipped because `xcodebuild` is unavailable.
+- Focused hostile mutations for either missing transition test, reversed style
+  pairings, removed final hierarchy assertions, documentation drift, and stale
+  plan status were rejected from a passing portable baseline.
+- `git diff --check`, intended-path, generated-artifact, structured-file, and
+  changed-line secret-pattern audits passed before shipment.
+- Exact-head hosted tvOS XCTest remains required on the pull request because it
+  is the executable macOS validation environment for this repository.

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -19,6 +19,7 @@ MODERN_XCODE_PLAN = DOCS_PLANS / "2026-06-10-modern-xcode-build.md"
 EXECUTABLE_TEST_PLAN = DOCS_PLANS / "2026-06-12-executable-appearance-tests.md"
 CODEQL_PLAN = DOCS_PLANS / "2026-06-12-codeql-manual-swift-build.md"
 INITIAL_ANNOUNCEMENT_PLAN = DOCS_PLANS / "2026-06-13-initial-appearance-announcement.md"
+TRAIT_TRANSITION_PLAN = DOCS_PLANS / "2026-06-13-controller-trait-transition-rendering.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 CODEQL_WORKFLOW = ROOT / ".github" / "workflows" / "codeql.yml"
 SHARED_SCHEME = ROOT / "tvos-darkmode.xcodeproj" / "xcshareddata" / "xcschemes" / "tvos-darkmode.xcscheme"
@@ -171,6 +172,10 @@ def check_docs_plans():
     require(
         INITIAL_ANNOUNCEMENT_PLAN.exists(),
         "docs/plans/2026-06-13-initial-appearance-announcement.md is missing",
+    )
+    require(
+        TRAIT_TRANSITION_PLAN.exists(),
+        "docs/plans/2026-06-13-controller-trait-transition-rendering.md is missing",
     )
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     require(plans, "docs/plans must contain at least one completed plan")
@@ -401,6 +406,8 @@ def check_executable_tests():
         "testDarkToLightStyleChangeAnnounces",
         "testDarkControllerRendersAppearanceHierarchy",
         "testLightControllerRendersAppearanceHierarchy",
+        "testDarkControllerRendersLightAppearanceAfterTraitChange",
+        "testLightControllerRendersDarkAppearanceAfterTraitChange",
         'XCTAssertEqual(presentation.text, "Dark Mode")',
         'XCTAssertEqual(presentation.text, "Light Mode")',
         'XCTAssertEqual(presentation.text, "Automatic Mode")',
@@ -408,6 +415,14 @@ def check_executable_tests():
         "container.setOverrideTraitCollection(",
         "UITraitCollection(userInterfaceStyle: style)",
         "controller.loadViewIfNeeded()",
+        "UITraitCollection(userInterfaceStyle: initialStyle)",
+        "UITraitCollection(userInterfaceStyle: currentStyle)",
+        "let initialPresentation = AppearancePresentation.resolve(for: initialStyle)",
+        "style: initialStyle",
+        "text: initialPresentation.text",
+        "backgroundColor: initialPresentation.backgroundColor",
+        "textColor: initialPresentation.textColor",
+        "style: currentStyle",
         "XCTAssertEqual(controller.traitCollection.userInterfaceStyle, style)",
         'XCTAssertEqual(controller.view.accessibilityIdentifier, "appearance-state-root-view")',
         ".compactMap { $0 as? UILabel }",
@@ -418,7 +433,26 @@ def check_executable_tests():
         "XCTAssertEqual(controller.view.backgroundColor, backgroundColor)",
     ):
         require(fragment in tests, f"XCTest coverage is missing: {fragment}")
+    for test_name, initial_style, current_style in (
+        ("testDarkControllerRendersLightAppearanceAfterTraitChange", "dark", "light"),
+        ("testLightControllerRendersDarkAppearanceAfterTraitChange", "light", "dark"),
+    ):
+        require(
+            re.search(
+                rf"func {test_name}\(\).*?assertControllerTransition\(\s*"
+                rf"from: \.{initial_style},\s*to: \.{current_style},",
+                tests,
+                re.DOTALL,
+            ),
+            f"{test_name} must preserve its {initial_style}-to-{current_style} transition",
+        )
     require("XCTFail" not in tests, "XCTest coverage must not contain placeholder failures")
+    for path, fragment in (
+        ("README.md", "bidirectional trait-transition rendering tests"),
+        ("VISION.md", "dark-to-light and light-to-dark rendering covered"),
+        ("CHANGES.md", "controller-level coverage for dark-to-light and light-to-dark"),
+    ):
+        require(fragment in read_text(path), f"{path} must document controller trait-transition coverage")
 
 
 def check_manual_verification_docs():

--- a/tvos-darkmodeTests/AppearancePresentationTests.swift
+++ b/tvos-darkmodeTests/AppearancePresentationTests.swift
@@ -69,6 +69,26 @@ final class AppearancePresentationTests: XCTestCase {
         )
     }
 
+    func testDarkControllerRendersLightAppearanceAfterTraitChange() {
+        assertControllerTransition(
+            from: .dark,
+            to: .light,
+            text: "Light Mode",
+            backgroundColor: .white,
+            textColor: .black
+        )
+    }
+
+    func testLightControllerRendersDarkAppearanceAfterTraitChange() {
+        assertControllerTransition(
+            from: .light,
+            to: .dark,
+            text: "Dark Mode",
+            backgroundColor: .black,
+            textColor: .white
+        )
+    }
+
     private func assertController(
         style: UIUserInterfaceStyle,
         text: String,
@@ -84,6 +104,61 @@ final class AppearancePresentationTests: XCTestCase {
         )
         controller.loadViewIfNeeded()
 
+        assertControllerAppearance(
+            controller,
+            style: style,
+            text: text,
+            backgroundColor: backgroundColor,
+            textColor: textColor
+        )
+    }
+
+    private func assertControllerTransition(
+        from initialStyle: UIUserInterfaceStyle,
+        to currentStyle: UIUserInterfaceStyle,
+        text: String,
+        backgroundColor: UIColor,
+        textColor: UIColor
+    ) {
+        let container = UIViewController()
+        let controller = ViewController()
+        container.addChild(controller)
+        container.setOverrideTraitCollection(
+            UITraitCollection(userInterfaceStyle: initialStyle),
+            forChild: controller
+        )
+        controller.loadViewIfNeeded()
+
+        let initialPresentation = AppearancePresentation.resolve(for: initialStyle)
+        assertControllerAppearance(
+            controller,
+            style: initialStyle,
+            text: initialPresentation.text,
+            backgroundColor: initialPresentation.backgroundColor,
+            textColor: initialPresentation.textColor
+        )
+
+        container.setOverrideTraitCollection(
+            UITraitCollection(userInterfaceStyle: currentStyle),
+            forChild: controller
+        )
+
+        assertControllerAppearance(
+            controller,
+            style: currentStyle,
+            text: text,
+            backgroundColor: backgroundColor,
+            textColor: textColor
+        )
+    }
+
+    private func assertControllerAppearance(
+        _ controller: ViewController,
+        style: UIUserInterfaceStyle,
+        text: String,
+        backgroundColor: UIColor,
+        textColor: UIColor
+    ) {
         XCTAssertEqual(controller.traitCollection.userInterfaceStyle, style)
         XCTAssertEqual(controller.view.accessibilityIdentifier, "appearance-state-root-view")
         let label = controller.view.subviews


### PR DESCRIPTION
## Summary

The tvOS sample now proves that an already-loaded controller follows both dark-to-light and light-to-dark trait changes, rather than validating only its initial appearance. The tests verify visible text, accessibility text, foreground color, and root background color before and after each transition without changing production behavior.

## Baseline

Hosted XCTest covered the appearance resolver, announcement decisions, and initial dark/light controller hierarchies. It did not execute the controller's central trait-change rendering path after the view had loaded.

## Improvements

- Adds bidirectional loaded-controller transition scenarios using the real UIKit child trait override path.
- Verifies the initial rendered baseline before each transition and the complete final presentation afterward.
- Extends portable contracts so missing tests, reversed direction pairs, weakened hierarchy assertions, documentation drift, or stale plan status fail closed.

## Validation

- `make check` passed under a 60-second hard timeout: all 8 portable contract groups passed; tvOS XCTest and build were explicitly skipped because this Linux host has no `xcodebuild`.
- Seven focused hostile mutations were rejected for the intended reasons.
- Plan-aware correctness, testing, Swift lifecycle, maintainability, and project-standards review found and fixed one initial-state assertion gap; no actionable findings remain.
- Intended-path, generated-artifact, structured-file, whitespace, and changed-line secret audits passed.

## Risk

This is test and contract coverage only; production Swift behavior is unchanged. The remaining validation risk is platform-specific execution, so the PR must retain a successful hosted macOS/Xcode tvOS XCTest job before merge.

## Follow-Ups

- Require exact-head static, tvOS XCTest, and CodeQL checks to finish successfully.
- Keep this PR stacked on `lfg/tvos-controller-rendering-20260613`; do not merge or close it without repository-owner authorization.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because the change affects only tests, maintenance docs, and portable contracts. The healthy signal is terminal-green exact-head hosted CI; any XCTest failure blocks delivery.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
