### PR TITLE
build: protect Make repository root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build check lint test verify
 
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 PYTHON ?= python3
 TVOS_DESTINATION ?= platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   dark/light hierarchy assertions and their non-visual boundary.
 - See `docs/plans/2026-06-13-controller-trait-transition-rendering.md` for
   loaded-controller dark/light transition coverage.
+- See `docs/plans/2026-06-14-make-root-override-protection.md` for repository-
+  anchored Make verification under hostile root assignments.
 - See `docs/plans/2026-06-12-codeql-manual-swift-build.md` for the explicit
   Swift CodeQL build baseline.
 

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,6 +1,6 @@
 # Make Root Override Protection
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -74,12 +74,32 @@ This change does not modify Swift logic, controller lifecycle, trait handling,
 VoiceOver behavior, storyboard/assets, project settings, schemes, tests,
 workflow policy, CodeQL, SDK versions, or deployment behavior.
 
-## Verification Plan
+## Work Completed
 
-- Run focused static contracts and Make dry-run checks.
-- Exercise all aliases from two working directories under hostile root
-  assignments while preserving explicit interpreter and destination selection.
-- Reject eight focused structural and evidence mutations.
-- Run `make check` with an explicit timeout and document local Xcode availability.
-- Review the exact plan-scoped diff and audit generated artifacts, changed-line
-  secrets, whitespace, and protected Swift/project/workflow paths.
+- Protected the derived repository root with GNU Make's `override` directive
+  while preserving configurable Python and simulator destination selection.
+- Added declaration-count, ordering, alias, checker/Xcode-path, README, and plan
+  contracts to the canonical tvOS checker.
+- Indexed the completed evidence without changing Swift, project, scheme,
+  workflow, CodeQL, SDK, or accessibility behavior.
+
+## Verification Results
+
+- All five public aliases passed dry-run verification from repository and
+  external working directories under hostile environment and command-line
+  `ROOT` assignments, for 20 bounded cases; explicit `PYTHON` and
+  `TVOS_DESTINATION` overrides remained effective.
+- Eight declaration protection, duplicate assignment, ordering, alias,
+  checker-path, README, missing-plan, and incomplete-plan mutations were
+  rejected.
+- A disposable exact-source snapshot passed the complete `make check` static
+  path with eight grouped tvOS contract checks and the documented no-Xcode test
+  and build skips.
+- The completed plan record passed the same gate from the repository and an
+  external working directory.
+- Hosted Xcode 16.4 tvOS XCTest and build remain the native exact-head authority.
+- Plan-aware correctness, build-integrity, tvOS, accessibility, testing,
+  maintainability, reliability, and project-standards review found no
+  actionable findings.
+- Exact diff, protected Swift/project/scheme/workflow/asset path,
+  generated-artifact, changed-line secret, and whitespace audits passed.

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,0 +1,85 @@
+# Make Root Override Protection
+
+## Status: Planned
+
+## Context
+
+The Makefile derives an absolute repository root so static, XCTest, and build
+aliases can run from outside the checkout. Its ordinary GNU Make assignment can
+still be replaced by an environment or command-line `ROOT`, redirecting the
+repository checker and Xcode working paths to another tree while a command
+appears to verify this checkout.
+
+Python and simulator destination selection are intentionally configurable.
+Repository ownership is not: every source, project, scheme, test, and evidence
+path must remain anchored to the checkout containing the invoked Makefile.
+
+## Requirements
+
+- Protect the derived repository root from environment and command-line
+  reassignment.
+- Preserve explicit `PYTHON` and `TVOS_DESTINATION` overrides and all five
+  public aliases.
+- Prove repository and external working-directory invocations remain anchored
+  under hostile root assignments.
+- Add mutation-sensitive contracts for the declaration, assignment count and
+  order, aliases, checker/Xcode paths, README index, and completed plan.
+- Preserve Swift, Xcode, tvOS appearance, accessibility, workflow, CodeQL, and
+  SDK behavior.
+
+## Approach
+
+Apply GNU Make's `override` directive only to the existing immediate root
+assignment. Keep it before the configurable interpreter and simulator
+destination declarations. Extend the canonical tvOS checker and use bounded
+dry-run cases to exercise GNU Make precedence without bypassing hosted Xcode.
+
+## Implementation Units
+
+### Protect repository path ownership
+
+- Update `Makefile` so exactly one protected root declaration owns repository
+  paths.
+- Retain the existing alias graph and both supported tool/destination overrides.
+
+### Add adversarial contracts
+
+- Extend `scripts/check_tvos_contracts.py` with declaration-count, ordering,
+  alias, checker/Xcode-path, README, and plan requirements.
+- Run all five aliases from repository and external directories under hostile
+  environment and command-line root assignments.
+- Reject declaration, duplication, ordering, alias, path, documentation, and
+  plan-state mutations.
+
+### Record completed evidence
+
+- Index this plan from `README.md`.
+- Mark it completed only after focused, mutation, full static, review, artifact,
+  secret, and exact-diff validation succeeds.
+
+## Risks And Mitigations
+
+- Protecting the destination or interpreter would prevent supported validation
+  customization. Only `ROOT` becomes protected; both configurable declarations
+  stay unchanged and receive explicit override checks.
+- A declaration-only assertion could miss a later reassignment or alias bypass.
+  Count all assignments and require the complete alias graph plus
+  repository-owned command paths.
+- Local Linux cannot execute tvOS builds or XCTest. Run the complete static gate
+  locally and retain hosted Xcode as the native exact-head authority.
+
+## Scope Boundaries
+
+This change does not modify Swift logic, controller lifecycle, trait handling,
+VoiceOver behavior, storyboard/assets, project settings, schemes, tests,
+workflow policy, CodeQL, SDK versions, or deployment behavior.
+
+## Verification Plan
+
+- Run focused static contracts and Make dry-run checks.
+- Exercise all aliases from two working directories under hostile root
+  assignments while preserving explicit interpreter and destination selection.
+- Reject eight focused structural and evidence mutations.
+- Run `make check` with an explicit timeout and document local Xcode availability.
+- Review the exact plan-scoped diff and audit generated artifacts, changed-line
+  secrets, whitespace, and protected Swift/project/workflow paths.

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -20,6 +20,7 @@ EXECUTABLE_TEST_PLAN = DOCS_PLANS / "2026-06-12-executable-appearance-tests.md"
 CODEQL_PLAN = DOCS_PLANS / "2026-06-12-codeql-manual-swift-build.md"
 INITIAL_ANNOUNCEMENT_PLAN = DOCS_PLANS / "2026-06-13-initial-appearance-announcement.md"
 TRAIT_TRANSITION_PLAN = DOCS_PLANS / "2026-06-13-controller-trait-transition-rendering.md"
+ROOT_OVERRIDE_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 CODEQL_WORKFLOW = ROOT / ".github" / "workflows" / "codeql.yml"
 SHARED_SCHEME = ROOT / "tvos-darkmode.xcodeproj" / "xcshareddata" / "xcschemes" / "tvos-darkmode.xcscheme"
@@ -176,6 +177,10 @@ def check_docs_plans():
     require(
         TRAIT_TRANSITION_PLAN.exists(),
         "docs/plans/2026-06-13-controller-trait-transition-rendering.md is missing",
+    )
+    require(
+        ROOT_OVERRIDE_PLAN.exists(),
+        "docs/plans/2026-06-14-make-root-override-protection.md is missing",
     )
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     require(plans, "docs/plans must contain at least one completed plan")
@@ -483,8 +488,27 @@ def check_ci_baseline_docs():
         "CodeQL workflow must match the exact pinned script and manual Swift build contract",
     )
     makefile = read_text("Makefile")
+    root_declaration = "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))"
+    root_assignments = re.findall(
+        r"^(?:override\s+)?ROOT\s*[:+?]?=", makefile, re.MULTILINE
+    )
+    require(
+        len(root_assignments) == 1 and makefile.count(root_declaration) == 1,
+        "Makefile must contain exactly one protected repository-root declaration",
+    )
+    require(
+        makefile.count(
+            f"{root_declaration}\nPYTHON ?= python3\n"
+            "TVOS_DESTINATION ?= platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5"
+        )
+        == 1,
+        "Makefile must keep the protected root before configurable tools",
+    )
     for contract in (
-        "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        ".PHONY: build check lint test verify",
+        "test: lint",
+        "verify: lint test build",
+        "check: verify",
         '$(PYTHON) "$(ROOT)/scripts/check_tvos_contracts.py"',
         "TVOS_DESTINATION ?= platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5",
         'cd "$(ROOT)" && xcodebuild',
@@ -494,6 +518,10 @@ def check_ci_baseline_docs():
         "CODE_SIGNING_ALLOWED=NO test",
     ):
         require(contract in makefile, f"Makefile must support invocation outside the repository: {contract}")
+    require(
+        "docs/plans/2026-06-14-make-root-override-protection.md" in read_text("README.md"),
+        "README.md must index Make root override protection evidence",
+    )
     for docs_file in ("README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
         require("GitHub Actions" in read_text(docs_file), f"{docs_file} must document the GitHub Actions baseline")
 


### PR DESCRIPTION
## Summary

Repository verification can no longer be redirected to another tree through environment or command-line `ROOT` assignments. Static checks and Xcode working paths remain anchored to this checkout while explicit Python and tvOS simulator destination selection continue to work.

## Baseline

The Makefile used an ordinary root assignment. GNU Make precedence therefore allowed callers to replace the derived checkout path and run repository-owned commands against unrelated source, project, or test inputs.

## Improvements

- protect the single derived repository root with GNU Make's `override` directive
- preserve all five public aliases plus configurable `PYTHON` and `TVOS_DESTINATION`
- add fail-closed declaration-count, ordering, alias, checker/Xcode path, README, and completed-plan contracts
- document the maintained build-integrity boundary without changing tvOS behavior

## Validation

- eight grouped tvOS static contract checks passed from the repository and an external working directory
- all five aliases passed dry-run checks from both locations under hostile environment and command-line root assignments (20 cases)
- explicit Python and simulator destination overrides remained effective
- eight declaration, duplication, ordering, alias, path, README, and plan mutations were rejected
- `make check` passed the documented local no-Xcode path; hosted Xcode remains the native XCTest/build authority
- plan-aware review found no actionable findings; exact-path, artifact, secret, and whitespace audits passed

## Risk

The change is limited to build and verification path ownership. It does not alter Swift behavior, controller lifecycle, trait handling, accessibility, storyboard/assets, project settings, schemes, tests, workflow policy, CodeQL, SDK versions, or deployment behavior. No post-deploy monitoring is required. Hosted static, Xcode, and CodeQL jobs remain the exact-head native authority.

## Follow-Ups

This PR is stacked on PR #5 and should remain open until its base is integrated or otherwise updated by the repository owner. No residual review findings remain.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
