### PR TITLE
Modernize tvOS trait observation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-16
+
+- Added focused tvOS 17 trait registration while preserving the tvOS 12 through
+  16 `traitCollectionDidChange` fallback through one transition handler.
+
 ## 2026-06-13
 
 - Added hosted controller-level coverage for dark-to-light and light-to-dark

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The project uses Swift 5 and has no third-party package dependencies.
   and bidirectional trait-transition rendering tests on the Apple TV 4K (3rd
   generation) tvOS 18.5 simulator when Xcode is available and reports an
   explicit skip on non-macOS hosts.
+- Appearance changes use focused trait registration on tvOS 17 and later while
+  preserving the `traitCollectionDidChange` fallback for the tvOS 12 floor.
 - `make build` compiles the Debug app for the tvOS simulator when Xcode is
   available and reports an explicit skip on non-macOS hosts.
 
@@ -147,6 +149,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   loaded-controller dark/light transition coverage.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for repository-
   anchored Make verification under hostile root assignments.
+- See `docs/plans/2026-06-16-modern-trait-observation.md` for focused modern
+  appearance observation with the legacy deployment-floor fallback.
 - See `docs/plans/2026-06-12-codeql-manual-swift-build.md` for the explicit
   Swift CodeQL build baseline.
 

--- a/VISION.md
+++ b/VISION.md
@@ -4,7 +4,8 @@ tvOS Dark Mode is a small Swift sample that observes trait collection changes
 and distinguishes light and dark user interface styles.
 
 The repository is useful as a minimal tvOS project for detecting appearance
-changes and wiring behavior to `traitCollectionDidChange`.
+changes through focused modern trait registration with a legacy deployment-
+floor fallback.
 
 The goal is to keep the sample focused on interface-style detection and make
 the supported tvOS/Xcode context clear.
@@ -34,6 +35,7 @@ Priority:
 - Keep dark and light controller hierarchy rendering covered by hosted XCTest
 - Keep loaded-controller dark-to-light and light-to-dark rendering covered by
   hosted XCTest
+- Keep focused tvOS 17 trait registration with a tvOS 12 through 16 fallback
 - Keep completed maintenance plans under `docs/plans`
 - Keep GitHub Actions running both portable contracts and hosted XCTest
 
@@ -41,7 +43,8 @@ Next priorities:
 
 - Add device or simulator screenshots for light and dark appearances
 - Add simulator-backed UI verification and screenshots
-- Replace deprecated trait-change observation when the deployment floor allows
+- Validate the modern and legacy trait-observation paths on supported Apple
+  platform versions
 
 Contribution rules:
 

--- a/docs/plans/2026-06-16-modern-trait-observation.md
+++ b/docs/plans/2026-06-16-modern-trait-observation.md
@@ -1,6 +1,6 @@
 # Modern Trait Observation
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -65,4 +65,13 @@ registration is active.
 
 ## Verification Completed
 
-Pending implementation and bounded verification.
+- Portable `make check` passed from the repository and through the absolute
+  Makefile path from an external directory; Linux truthfully skipped native
+  tvOS build and XCTest because `xcodebuild` is unavailable.
+- Eight hostile modern trait observation mutations were rejected across the
+  focused registration, availability guards, shared routing, guidance, and
+  completed plan.
+- Exact diff, generated-artifact, secret, conflict-marker, binary, large-file,
+  and whitespace audits passed for the intended paths.
+- Native Xcode 16.4 compilation and tvOS 18.5 XCTest remain required from the
+  pull request's bounded hosted snapshot before this stack is merge-ready.

--- a/docs/plans/2026-06-16-modern-trait-observation.md
+++ b/docs/plans/2026-06-16-modern-trait-observation.md
@@ -1,0 +1,68 @@
+# Modern Trait Observation
+
+## Status: Planned
+
+## Context
+
+`ViewController` still observes appearance changes exclusively through
+`traitCollectionDidChange(_:)`. UIKit deprecated that callback in tvOS 17 and
+recommends registering only the traits an object needs. The sample still
+supports tvOS 12, so removing the callback outright would break the deployment
+floor.
+
+## Priority
+
+P1 compatibility and maintainability. Use current UIKit trait observation on
+tvOS 17 and later without duplicating appearance updates or accessibility
+announcements, while preserving the existing tvOS 12 through 16 fallback.
+
+## Requirements
+
+- Register specifically for `UITraitUserInterfaceStyle` changes on tvOS 17+.
+- Route modern registration and the legacy callback through one transition
+  handler.
+- Keep `traitCollectionDidChange(_:)` active only below tvOS 17.
+- Preserve initial rendering, bidirectional appearance updates, and the rule
+  that missing or unchanged prior styles do not announce.
+- Add portable static contracts and hosted XCTest coverage for the modern and
+  fallback structure without raising the tvOS deployment target.
+
+## Approach
+
+Register during `viewDidLoad()` after the initial appearance is rendered. The
+registration handler receives the previous trait collection and delegates to a
+shared appearance-transition method. The legacy override returns immediately
+on tvOS 17+, preventing duplicate updates and announcements when the modern
+registration is active.
+
+## Verification
+
+- Run portable contracts from the repository and through the absolute Makefile
+  path from an external directory.
+- Require hosted tvOS XCTest to compile and execute the availability-gated
+  modern API and legacy fallback.
+- Reject mutations that remove registration, broaden the observed traits,
+  remove the availability guard, bypass the shared handler, duplicate update
+  logic, weaken tests, or leave this plan incomplete.
+- Audit exact paths, generated artifacts, secrets, conflict markers, binaries,
+  large files, and whitespace.
+
+## Scope Boundaries
+
+- Do not raise the tvOS 12 deployment target.
+- Do not alter appearance colors, labels, accessibility copy, constraints,
+  storyboard structure, project signing, workflow shape, or dependencies.
+- Simulator screenshots and physical VoiceOver evidence remain separate macOS
+  or device validation.
+
+## Success Criteria
+
+- tvOS 17+ observes only user-interface-style changes through
+  `registerForTraitChanges`.
+- tvOS 12 through 16 retain the legacy callback.
+- Every real style transition updates once and announces once.
+- Portable and hosted gates preserve both paths.
+
+## Verification Completed
+
+Pending implementation and bounded verification.

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -21,6 +21,7 @@ CODEQL_PLAN = DOCS_PLANS / "2026-06-12-codeql-manual-swift-build.md"
 INITIAL_ANNOUNCEMENT_PLAN = DOCS_PLANS / "2026-06-13-initial-appearance-announcement.md"
 TRAIT_TRANSITION_PLAN = DOCS_PLANS / "2026-06-13-controller-trait-transition-rendering.md"
 ROOT_OVERRIDE_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
+MODERN_TRAIT_OBSERVATION_PLAN = DOCS_PLANS / "2026-06-16-modern-trait-observation.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 CODEQL_WORKFLOW = ROOT / ".github" / "workflows" / "codeql.yml"
 SHARED_SCHEME = ROOT / "tvos-darkmode.xcodeproj" / "xcshareddata" / "xcschemes" / "tvos-darkmode.xcscheme"
@@ -182,6 +183,10 @@ def check_docs_plans():
         ROOT_OVERRIDE_PLAN.exists(),
         "docs/plans/2026-06-14-make-root-override-protection.md is missing",
     )
+    require(
+        MODERN_TRAIT_OBSERVATION_PLAN.exists(),
+        "docs/plans/2026-06-16-modern-trait-observation.md is missing",
+    )
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     require(plans, "docs/plans must contain at least one completed plan")
     for plan_path in plans:
@@ -327,6 +332,23 @@ def check_visible_appearance_state():
         and "argument: appearanceLabel.accessibilityLabel)" in view_controller,
         "appearance changes must announce the updated state to assistive technologies",
     )
+    modern_observation = re.search(
+        r"private func configureAppearanceObservation\(\).*?\n    \}",
+        view_controller,
+        re.DOTALL,
+    )
+    require(modern_observation is not None, "modern appearance observation must be configured")
+    require(
+        "if #available(tvOS 17.0, *)" in modern_observation.group(0)
+        and "registerForTraitChanges([UITraitUserInterfaceStyle.self])" in modern_observation.group(0)
+        and "controller.handleAppearanceTransition(from: previousTraitCollection)"
+        in modern_observation.group(0),
+        "tvOS 17 must register only user-interface-style changes through the shared handler",
+    )
+    require(
+        view_controller.count("registerForTraitChanges(") == 1,
+        "appearance observation must have exactly one focused modern registration",
+    )
     trait_change = re.search(
         r"override func traitCollectionDidChange.*?\n    \}",
         view_controller,
@@ -334,8 +356,23 @@ def check_visible_appearance_state():
     )
     require(trait_change is not None, "traitCollectionDidChange must remain implemented")
     require(
-        trait_change.group(0).index("updateAppearance(for: traitCollection)")
-        < trait_change.group(0).index("UIAccessibility.post(notification: .announcement,"),
+        "if #available(tvOS 17.0, *)" in trait_change.group(0)
+        and "return" in trait_change.group(0)
+        and "handleAppearanceTransition(from: previousTraitCollection)"
+        in trait_change.group(0),
+        "legacy trait changes must run only below tvOS 17 through the shared handler",
+    )
+    transition_handler = re.search(
+        r"private func handleAppearanceTransition.*?\n    \}",
+        view_controller,
+        re.DOTALL,
+    )
+    require(transition_handler is not None, "appearance transitions must use a shared handler")
+    require(
+        transition_handler.group(0).index("updateAppearance(for: traitCollection)")
+        < transition_handler.group(0).index(
+            "UIAccessibility.post(notification: .announcement,"
+        ),
         "appearance state must update before its accessibility announcement",
     )
     require(
@@ -345,7 +382,7 @@ def check_visible_appearance_state():
         "appearance announcements must require a known, changed previous style",
     )
     require(
-        "AppearancePresentation.shouldAnnounceChange(" in trait_change.group(0),
+        "AppearancePresentation.shouldAnnounceChange(" in transition_handler.group(0),
         "trait changes must use the tested announcement predicate",
     )
     require(
@@ -458,6 +495,20 @@ def check_executable_tests():
         ("CHANGES.md", "controller-level coverage for dark-to-light and light-to-dark"),
     ):
         require(fragment in read_text(path), f"{path} must document controller trait-transition coverage")
+    for path, fragment in (
+        ("README.md", "focused trait registration on tvOS 17"),
+        ("VISION.md", "focused tvOS 17 trait registration"),
+        ("CHANGES.md", "focused tvOS 17 trait registration"),
+    ):
+        require(fragment in read_text(path), f"{path} must document modern trait observation")
+    require(
+        "docs/plans/2026-06-16-modern-trait-observation.md" in read_text("README.md"),
+        "README.md must index modern trait observation evidence",
+    )
+    require(
+        "wiring behavior to `traitCollectionDidChange`" not in read_text("VISION.md"),
+        "VISION.md must not describe the legacy callback as the sole observation path",
+    )
 
 
 def check_manual_verification_docs():

--- a/tvos-darkmode/ViewController.swift
+++ b/tvos-darkmode/ViewController.swift
@@ -52,11 +52,29 @@ final class ViewController: UIViewController {
         view.accessibilityIdentifier = "appearance-state-root-view"
         configureAppearanceLabel()
         updateAppearance(for: traitCollection)
+        configureAppearanceObservation()
+    }
+
+    private func configureAppearanceObservation() {
+        if #available(tvOS 17.0, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) {
+                (controller: ViewController, previousTraitCollection: UITraitCollection) in
+                controller.handleAppearanceTransition(from: previousTraitCollection)
+            }
+        }
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
+        if #available(tvOS 17.0, *) {
+            return
+        }
+
+        handleAppearanceTransition(from: previousTraitCollection)
+    }
+
+    private func handleAppearanceTransition(from previousTraitCollection: UITraitCollection?) {
         guard AppearancePresentation.shouldAnnounceChange(
             from: previousTraitCollection?.userInterfaceStyle,
             to: traitCollection.userInterfaceStyle


### PR DESCRIPTION
## Summary

Use UIKit's focused trait-change registration on tvOS 17 and later while
preserving the tvOS 12 through 16 callback fallback.

## Baseline

The controller observed every trait change exclusively through the deprecated
`traitCollectionDidChange(_:)` callback, even on tvOS 17 and later.

## Improvements

- Register only `UITraitUserInterfaceStyle` changes on tvOS 17+.
- Keep the legacy callback below tvOS 17 without raising the deployment floor.
- Route both paths through one predicate, rendering, and announcement handler.
- Extend portable contracts, maintenance guidance, and completed plan evidence.

## Validation

- Repository portable `make check`: passed.
- Absolute-Makefile `make check` from `/tmp`: passed.
- Eight hostile mutations: all rejected.
- Checker Python syntax: passed.
- Exact diff, generated-artifact, secret, conflict, binary, size, and whitespace
  audits: passed.
- Native Xcode 16.4 build and tvOS 18.5 XCTest: required from hosted checks.

## Risk

Moderate until hosted compilation completes. UIKit is unavailable on the Linux
workstation, so the availability-gated API spelling and modern transition path
must compile and execute in the pinned macOS/Xcode job. The legacy deployment
floor and visual behavior are otherwise unchanged.

## Follow-Ups

Capture simulator screenshots and physical-device VoiceOver evidence on an
Apple platform. Keep this PR stacked on PR #6 and merge base-first only after
all canonical checks are green.
