### PR TITLE
Create missing tvOS simulator in CI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   and storyboard fallback required by the deployment floor.
 - Made local XCTest select the named simulator available to the chosen Xcode
   and isolated DerivedData under the ignored repository `.build` directory.
+- Made hosted XCTest create the matching Apple TV simulator when a runner has
+  an installed tvOS runtime but no pre-created device.
 - Added main-actor UI ownership and five state tests covering initial,
   repeated, hidden, inactive, and round-trip appearance transitions.
 

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,18 @@
 
 override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 PYTHON ?= python3
-TVOS_DESTINATION ?= platform=tvOS Simulator,name=Apple TV 4K (3rd generation)
+TVOS_DESTINATION ?=
 DERIVED_DATA_PATH ?= $(ROOT)/.build/DerivedData
 
 lint:
 	$(PYTHON) "$(ROOT)/scripts/check_tvos_contracts.py"
+	cd "$(ROOT)" && $(PYTHON) -m unittest discover -s tests -p 'test_*.py'
 
 test: lint
 	@if command -v xcodebuild >/dev/null 2>&1; then \
-		cd "$(ROOT)" && xcodebuild -project tvos-darkmode.xcodeproj -scheme tvos-darkmode -destination "$(TVOS_DESTINATION)" -derivedDataPath "$(DERIVED_DATA_PATH)" -configuration Debug CODE_SIGNING_ALLOWED=NO test; \
+		destination='$(TVOS_DESTINATION)'; \
+		if [ -z "$$destination" ]; then destination="$$($(PYTHON) "$(ROOT)/scripts/select_tvos_destination.py")"; fi; \
+		cd "$(ROOT)" && xcodebuild -project tvos-darkmode.xcodeproj -scheme tvos-darkmode -destination "$$destination" -derivedDataPath "$(DERIVED_DATA_PATH)" -configuration Debug CODE_SIGNING_ALLOWED=NO test; \
 	else \
 		echo "tvOS XCTest skipped: xcodebuild is not available on this host."; \
 	fi

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ The project uses Swift 5 and has no third-party package dependencies.
 - Static checks also require completed canonical plans under `docs/plans`.
 - `make test` executes resolver, announcement, initial controller hierarchy,
   and bidirectional trait-transition rendering tests on the Apple TV 4K (3rd
-  generation) simulator available to the selected Xcode. Hosted CI remains
-  deterministic because Xcode 16.4 supplies the tvOS 18.5 runtime. Derived
-  data stays under the repository's ignored `.build` directory.
+  generation) simulator available to the selected Xcode. It reuses the newest
+  installed matching device or creates one from the newest installed tvOS
+  runtime when a hosted runner has no pre-created simulator. Derived data stays
+  under the repository's ignored `.build` directory.
 - Appearance changes use focused trait registration on tvOS 17 and later while
   preserving the `traitCollectionDidChange` fallback for the tvOS 12 floor.
 - A small transition state machine renders every changed appearance but only

--- a/docs/plans/2026-06-19-tvos-lifecycle-deep-review.md
+++ b/docs/plans/2026-06-19-tvos-lifecycle-deep-review.md
@@ -50,3 +50,13 @@ the named simulator runtime supplied by the selected Xcode.
   commits. GitHub reported zero open code-scanning, secret-scanning, and
   Dependabot alerts.
 - Hosted Check and CodeQL: required before merge.
+
+## Post-Merge Gate Correction
+
+The PR-head Check and CodeQL runs passed, but exact-master Check run
+`27855771060` landed on a macOS runner with no pre-created tvOS simulator and
+failed destination resolution before compilation. The follow-up selector reads
+the installed CoreSimulator inventory, reuses the newest available matching
+Apple TV device, or creates one from the newest installed tvOS runtime. Three
+unit tests cover newest-runtime selection, device creation, and the no-runtime
+failure. Exact-master hosted verification is required again after the follow-up.

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -569,6 +569,8 @@ def check_ci_baseline_docs():
         "CodeQL workflow must match the exact pinned script and manual Swift build contract",
     )
     makefile = read_text("Makefile")
+    selector = read_text("scripts/select_tvos_destination.py")
+    selector_tests = read_text("tests/test_select_tvos_destination.py")
     root_declaration = "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))"
     root_assignments = re.findall(
         r"^(?:override\s+)?ROOT\s*[:+?]?=", makefile, re.MULTILINE
@@ -580,7 +582,7 @@ def check_ci_baseline_docs():
     require(
         makefile.count(
             f"{root_declaration}\nPYTHON ?= python3\n"
-            "TVOS_DESTINATION ?= platform=tvOS Simulator,name=Apple TV 4K (3rd generation)\n"
+            "TVOS_DESTINATION ?=\n"
             "DERIVED_DATA_PATH ?= $(ROOT)/.build/DerivedData"
         )
         == 1,
@@ -592,16 +594,32 @@ def check_ci_baseline_docs():
         "verify: lint test build",
         "check: verify",
         '$(PYTHON) "$(ROOT)/scripts/check_tvos_contracts.py"',
-        "TVOS_DESTINATION ?= platform=tvOS Simulator,name=Apple TV 4K (3rd generation)",
+        "TVOS_DESTINATION ?=",
         "DERIVED_DATA_PATH ?= $(ROOT)/.build/DerivedData",
+        "scripts/select_tvos_destination.py",
+        "$(PYTHON) -m unittest discover",
         'cd "$(ROOT)" && xcodebuild',
         '-destination "generic/platform=tvOS Simulator"',
-        '-destination "$(TVOS_DESTINATION)"',
+        '-destination "$$destination"',
         '-derivedDataPath "$(DERIVED_DATA_PATH)"',
         "CODE_SIGNING_ALLOWED=NO",
         "CODE_SIGNING_ALLOWED=NO test",
     ):
         require(contract in makefile, f"Makefile must support invocation outside the repository: {contract}")
+    for fragment in (
+        'DEVICE_NAME = "Apple TV 4K (3rd generation)"',
+        '["xcrun", "simctl", "list", "--json"]',
+        '["xcrun", "simctl", "create", name, device_type, runtime]',
+        'return f"platform=tvOS Simulator,id={device[\'udid\']}"',
+        'raise RuntimeError("no available tvOS simulator runtime is installed")',
+    ):
+        require(fragment in selector, f"simulator selector is missing: {fragment}")
+    for test_name in (
+        "test_uses_matching_device_from_newest_available_runtime",
+        "test_creates_matching_device_when_runtime_has_no_device",
+        "test_rejects_missing_available_tvos_runtime",
+    ):
+        require(test_name in selector_tests, f"simulator selector test is missing: {test_name}")
     require(
         "docs/plans/2026-06-14-make-root-override-protection.md" in read_text("README.md"),
         "README.md must index Make root override protection evidence",

--- a/scripts/select_tvos_destination.py
+++ b/scripts/select_tvos_destination.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Select or create a usable Apple TV simulator destination."""
+
+import json
+import re
+import subprocess
+import sys
+
+
+DEVICE_NAME = "Apple TV 4K (3rd generation)"
+CREATED_DEVICE_NAME = "tv-os-darkmode CI"
+
+
+def version_key(version):
+    return tuple(int(component) for component in re.findall(r"\d+", version))
+
+
+def select_destination(payload, create_device):
+    runtimes = [
+        runtime
+        for runtime in payload.get("runtimes", [])
+        if ".tvOS-" in runtime.get("identifier", "")
+        and runtime.get("isAvailable", True)
+    ]
+    if not runtimes:
+        raise RuntimeError("no available tvOS simulator runtime is installed")
+
+    runtime = max(runtimes, key=lambda item: version_key(item.get("version", "0")))
+    runtime_identifier = runtime["identifier"]
+    devices = payload.get("devices", {}).get(runtime_identifier, [])
+    for device in devices:
+        if device.get("name") == DEVICE_NAME and device.get("isAvailable", True):
+            return f"platform=tvOS Simulator,id={device['udid']}"
+
+    device_type = next(
+        (
+            item["identifier"]
+            for item in payload.get("devicetypes", [])
+            if item.get("name") == DEVICE_NAME
+        ),
+        None,
+    )
+    if device_type is None:
+        raise RuntimeError(f"simulator device type is unavailable: {DEVICE_NAME}")
+
+    udid = create_device(CREATED_DEVICE_NAME, device_type, runtime_identifier)
+    return f"platform=tvOS Simulator,id={udid}"
+
+
+def create_device(name, device_type, runtime):
+    return subprocess.check_output(
+        ["xcrun", "simctl", "create", name, device_type, runtime],
+        text=True,
+    ).strip()
+
+
+def main():
+    try:
+        payload = json.loads(
+            subprocess.check_output(
+                ["xcrun", "simctl", "list", "--json"],
+                text=True,
+            )
+        )
+        print(select_destination(payload, create_device=create_device))
+    except (json.JSONDecodeError, KeyError, OSError, RuntimeError, subprocess.CalledProcessError) as exc:
+        print(f"select_tvos_destination.py: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_select_tvos_destination.py
+++ b/tests/test_select_tvos_destination.py
@@ -1,0 +1,103 @@
+import unittest
+
+from scripts.select_tvos_destination import select_destination
+
+
+class SelectTVOSDestinationTests(unittest.TestCase):
+    def test_uses_matching_device_from_newest_available_runtime(self):
+        payload = {
+            "devices": {
+                "com.apple.CoreSimulator.SimRuntime.tvOS-18-5": [
+                    {
+                        "name": "Apple TV 4K (3rd generation)",
+                        "udid": "OLDER",
+                        "isAvailable": True,
+                    }
+                ],
+                "com.apple.CoreSimulator.SimRuntime.tvOS-26-0": [
+                    {
+                        "name": "Apple TV 4K (3rd generation)",
+                        "udid": "NEWER",
+                        "isAvailable": True,
+                    }
+                ],
+            },
+            "runtimes": [
+                {
+                    "identifier": "com.apple.CoreSimulator.SimRuntime.tvOS-18-5",
+                    "version": "18.5",
+                    "isAvailable": True,
+                },
+                {
+                    "identifier": "com.apple.CoreSimulator.SimRuntime.tvOS-26-0",
+                    "version": "26.0",
+                    "isAvailable": True,
+                },
+            ],
+            "devicetypes": [],
+        }
+
+        destination = select_destination(payload, create_device=lambda *_: self.fail())
+
+        self.assertEqual(destination, "platform=tvOS Simulator,id=NEWER")
+
+    def test_creates_matching_device_when_runtime_has_no_device(self):
+        payload = {
+            "devices": {
+                "com.apple.CoreSimulator.SimRuntime.tvOS-18-5": [],
+            },
+            "runtimes": [
+                {
+                    "identifier": "com.apple.CoreSimulator.SimRuntime.tvOS-18-5",
+                    "version": "18.5",
+                    "isAvailable": True,
+                }
+            ],
+            "devicetypes": [
+                {
+                    "name": "Apple TV 4K (3rd generation)",
+                    "identifier": "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K",
+                }
+            ],
+        }
+        calls = []
+
+        destination = select_destination(
+            payload,
+            create_device=lambda name, device_type, runtime: calls.append(
+                (name, device_type, runtime)
+            )
+            or "CREATED",
+        )
+
+        self.assertEqual(destination, "platform=tvOS Simulator,id=CREATED")
+        self.assertEqual(
+            calls,
+            [
+                (
+                    "tv-os-darkmode CI",
+                    "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K",
+                    "com.apple.CoreSimulator.SimRuntime.tvOS-18-5",
+                )
+            ],
+        )
+
+    def test_rejects_missing_available_tvos_runtime(self):
+        payload = {
+            "devices": {},
+            "runtimes": [
+                {
+                    "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-18-5",
+                    "version": "18.5",
+                    "isAvailable": True,
+                }
+            ],
+            "devicetypes": [],
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "available tvOS simulator runtime"):
+            select_destination(payload, create_device=lambda *_: self.fail())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and merge state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #9 remains merged at head `b1fb2d6ed46c072f49fc9019fd79fcea251ae02f`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary

Fixes the exact-master failure from Check run `27855771060` after #8 merged.

The macOS runner had Xcode 16.4 and the tvOS toolchain, but no pre-created Apple TV simulator. The name-only destination therefore resolved to `OS:latest` and failed before compilation.

- inspect the installed CoreSimulator inventory
- reuse the matching Apple TV device from the newest available tvOS runtime
- create the matching device when the runtime exists but the runner has no device
- retain explicit `TVOS_DESTINATION` override support
- run selector unit tests in the portable Make gate

## Validation

- three selector unit tests pass
- `make check` passes with 12 tvOS XCTest cases on Xcode 26.0.1 / tvOS 26
- external `/tmp` Make invocation passes with hostile `ROOT=/tmp`
- newest-runtime, device-name, and hard-coded-destination mutations were killed
- current-tree redacted Gitleaks scan has zero findings

## Residual Risk

A runner with no installed tvOS simulator runtime fails clearly instead of attempting a large unbounded download. Physical Apple TV and older-runtime behavior remain manual checks.

