### PR TITLE
build: harden tvOS verification authority

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Run baseline
-        run: make check
+        run: ./scripts/run-make.sh check
 
   xcode-test:
     runs-on: macos-15
@@ -41,4 +41,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run tvOS XCTest
-        run: make test
+        run: ./scripts/run-make.sh test

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,11 @@
 - Added a fixed `scripts/run-make.sh` entrypoint for hosted `check` and `test`
   runs. It clears inherited Make control variables, rejects options,
   assignments, extra targets, and alternate Makefiles, and invokes the physical
-  repository Makefile through fixed system tools. Regression tests reproduce
-  raw `--eval`, dry-run, ignore-errors, `GNUMAKEFLAGS`, `MAKEFILES`, and earlier
-  `-f` authority before proving the wrapper excludes those channels.
+  repository Makefile through fixed system tools. It resolves bounded relative
+  and absolute script symlink chains without losing spaces, quotes, or newline
+  bytes, and rejects broken or overlong chains. Regression tests reproduce raw
+  `--eval`, dry-run, ignore-errors, `GNUMAKEFLAGS`, `MAKEFILES`, and earlier `-f`
+  authority before proving the wrapper excludes those channels.
 - Hardened repository Make rules against Make-syntax interpreter injection,
   caller shell replacement, visible non-executing flags, populated `MAKEFILES`,
   `MAKEFILE_LIST` root substitution, and root redirection while preserving

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+- Hardened `make check` against Make-syntax interpreter injection, caller shell
+  replacement, non-executing flags, populated `MAKEFILES`, and root redirection;
+  rejected `MAKEFILE_LIST` root substitution, documented the remaining
+  startup/later-`-f` parse boundary, and preserved literal Python and tvOS
+  destination overrides.
+
 ## 2026-06-19
 
 - Added a deterministic appearance transition state that suppresses duplicate,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,15 @@
 # Changes
 
-- Hardened `make check` against Make-syntax interpreter injection, caller shell
-  replacement, non-executing flags, populated `MAKEFILES`, and root redirection;
-  rejected `MAKEFILE_LIST` root substitution, documented the remaining
-  startup/later-`-f` parse boundary, and preserved literal Python and tvOS
-  destination overrides.
+- Added a fixed `scripts/run-make.sh` entrypoint for hosted `check` and `test`
+  runs. It clears inherited Make control variables, rejects options,
+  assignments, extra targets, and alternate Makefiles, and invokes the physical
+  repository Makefile through fixed system tools. Regression tests reproduce
+  raw `--eval`, dry-run, ignore-errors, `GNUMAKEFLAGS`, `MAKEFILES`, and earlier
+  `-f` authority before proving the wrapper excludes those channels.
+- Hardened repository Make rules against Make-syntax interpreter injection,
+  caller shell replacement, visible non-executing flags, populated `MAKEFILES`,
+  `MAKEFILE_LIST` root substitution, and root redirection while preserving
+  literal Python and tvOS destination overrides.
 
 ## 2026-06-19
 

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,87 @@
-.PHONY: build check lint test verify
+.DEFAULT_GOAL := check
+.PHONY: __repository-make-authority build check lint root-test test verify
 
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+PUBLIC_TARGETS := build check lint root-test test verify
+
 PYTHON ?= python3
+override PYTHON := $(value PYTHON)
+export PYTHON
+override REPOSITORY_MAKE_DOLLAR := $$
+override REPOSITORY_MAKE_OPEN := (
+ifneq ($(findstring $(REPOSITORY_MAKE_DOLLAR)$(REPOSITORY_MAKE_OPEN),$(value PYTHON)),)
+$(error PYTHON must be a literal executable path, not Make syntax)
+endif
+override SHELL := /bin/sh
+override .SHELLFLAGS := -c
+
+ifneq ($(filter command line,$(origin MAKEFLAGS)),)
+$(error MAKEFLAGS must not be overridden for repository verification)
+endif
+override REPOSITORY_MAKE_FIRST_FLAGS := $(firstword $(MAKEFLAGS))
+ifneq ($(filter -%,$(REPOSITORY_MAKE_FIRST_FLAGS)),)
+override REPOSITORY_MAKE_FIRST_FLAGS :=
+endif
+override REPOSITORY_MAKE_SHORT_FLAGS := $(REPOSITORY_MAKE_FIRST_FLAGS) $(filter-out --%,$(filter -%,$(MAKEFLAGS)))
+ifneq ($(findstring n,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring t,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring q,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring i,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(filter --just-print --dry-run --recon --touch --question --ignore-errors,$(MAKEFLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override REPOSITORY_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+override REPOSITORY_ROOT := $(abspath $(dir $(REPOSITORY_MAKEFILE)))
+override ROOT := $(REPOSITORY_ROOT)
+export ROOT
 TVOS_DESTINATION ?=
 DERIVED_DATA_PATH ?= $(ROOT)/.build/DerivedData
 
+$(PUBLIC_TARGETS): override SHELL := /bin/sh
+$(PUBLIC_TARGETS): override .SHELLFLAGS := -c
+$(PUBLIC_TARGETS): override ROOT := $(REPOSITORY_ROOT)
+$(PUBLIC_TARGETS): __repository-make-authority
+
+__repository-make-authority:
+	@:
+
 lint:
-	$(PYTHON) "$(ROOT)/scripts/check_tvos_contracts.py"
-	cd "$(ROOT)" && $(PYTHON) -m unittest discover -s tests -p 'test_*.py'
+	"$$PYTHON" "$$ROOT/scripts/check_tvos_contracts.py"
+	cd "$$ROOT" && "$$PYTHON" -m unittest discover -s tests -p 'test_*.py'
 
 test: lint
 	@if command -v xcodebuild >/dev/null 2>&1; then \
 		destination='$(TVOS_DESTINATION)'; \
-		if [ -z "$$destination" ]; then destination="$$($(PYTHON) "$(ROOT)/scripts/select_tvos_destination.py")"; fi; \
-		cd "$(ROOT)" && xcodebuild -project tvos-darkmode.xcodeproj -scheme tvos-darkmode -destination "$$destination" -derivedDataPath "$(DERIVED_DATA_PATH)" -configuration Debug CODE_SIGNING_ALLOWED=NO test; \
+		if [ -z "$$destination" ]; then destination="$$($$PYTHON "$$ROOT/scripts/select_tvos_destination.py")"; fi; \
+		cd "$$ROOT" && xcodebuild -project tvos-darkmode.xcodeproj -scheme tvos-darkmode -destination "$$destination" -derivedDataPath "$(DERIVED_DATA_PATH)" -configuration Debug CODE_SIGNING_ALLOWED=NO test; \
 	else \
 		echo "tvOS XCTest skipped: xcodebuild is not available on this host."; \
 	fi
 
 build:
 	@if command -v xcodebuild >/dev/null 2>&1; then \
-		cd "$(ROOT)" && xcodebuild -project tvos-darkmode.xcodeproj -scheme tvos-darkmode -destination "generic/platform=tvOS Simulator" -derivedDataPath "$(DERIVED_DATA_PATH)" -configuration Debug CODE_SIGNING_ALLOWED=NO build; \
+		cd "$$ROOT" && xcodebuild -project tvos-darkmode.xcodeproj -scheme tvos-darkmode -destination "generic/platform=tvOS Simulator" -derivedDataPath "$(DERIVED_DATA_PATH)" -configuration Debug CODE_SIGNING_ALLOWED=NO build; \
 	else \
 		echo "tvOS build skipped: xcodebuild is not available on this host."; \
 	fi
 
-verify: lint test build
+root-test:
+	/bin/sh "$$ROOT/scripts/test-makefile-authority.sh"
+
+verify: root-test lint test build
 
 check: verify

--- a/README.md
+++ b/README.md
@@ -75,10 +75,12 @@ The project uses Swift 5 and has no third-party package dependencies.
   accessibility-hint, display-only, root-view identifier, and contrast
   contract checks. It also enforces Swift 5, the tvOS 12 deployment floor,
   modern UIKit launch APIs, and hosted Xcode compilation.
-- The trusted wrapper accepts exactly `check` or `test`, resolves the physical
-  repository Makefile with fixed system tools, clears `MAKEFILES`, `MAKEFLAGS`,
-  `MFLAGS`, `MAKEOVERRIDES`, and `GNUMAKEFLAGS`, and invokes fixed
-  `/usr/bin/make` with no caller-supplied options, assignments, or extra files.
+- The trusted wrapper accepts exactly `check` or `test`, resolves its physical
+  script through a bounded relative or absolute symlink chain, rejects broken
+  or overlong resolutions, then selects the adjacent repository Makefile with
+  fixed system tools. It clears `MAKEFILES`, `MAKEFLAGS`, `MFLAGS`,
+  `MAKEOVERRIDES`, and `GNUMAKEFLAGS`, and invokes fixed `/usr/bin/make` with no
+  caller-supplied options, assignments, or extra files.
   Direct `make` commands remain caller authority: startup files, earlier `-f`
   files, and options such as `--eval`, dry-run, or ignore-errors are processed
   before the repository Makefile can validate them.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ The project uses Swift 5 and has no third-party package dependencies.
   accessibility-hint, display-only, root-view identifier, and contrast
   contract checks. It also enforces Swift 5, the tvOS 12 deployment floor,
   modern UIKit launch APIs, and hosted Xcode compilation.
+- When invoked with the checked-in Makefile alone, the Make entry point protects
+  repository paths and recipe shells, rejects non-executing flags, stops when
+  `MAKEFILES` is populated, rejects `MAKEFILE_LIST` replacement, and accepts
+  only literal `PYTHON` overrides.
+  GNU Make startup files execute during parsing, and caller-supplied later `-f`
+  files remain outside this repository trust boundary.
 - Static checks also require completed canonical plans under `docs/plans`.
 - `make test` executes resolver, announcement, initial controller hierarchy,
   and bidirectional trait-transition rendering tests on the Apple TV 4K (3rd
@@ -161,6 +167,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   loaded-controller dark/light transition coverage.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for repository-
   anchored Make verification under hostile root assignments.
+- See `docs/plans/2026-06-21-make-authority-hardening.md` for interpreter,
+  shell, startup-file, and execution-mode authority checks.
 - See `docs/plans/2026-06-16-modern-trait-observation.md` for focused modern
   appearance observation with the legacy deployment-floor fallback.
 - See `docs/plans/2026-06-19-tvos-lifecycle-deep-review.md` for scene lifecycle,

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The project uses Swift 5 and has no third-party package dependencies.
 ## Running or Using the Project
 
 - Open `tvos-darkmode.xcodeproj` in Xcode, choose the app or sample scheme, and run it on the matching simulator/device.
-- Run `make check` for static repository checks, executable XCTest when Xcode
-  is available, and unsigned simulator compilation.
+- Run `./scripts/run-make.sh check` for static repository checks, executable
+  XCTest when Xcode is available, and unsigned simulator compilation.
 - GitHub Actions runs the portable contract gate on Ubuntu 24.04 and executes
   XCTest with Xcode 16.4 on macOS 15. Both jobs have read-only repository
   permissions, disabled checkout credential persistence, bounded timeouts, and
@@ -69,24 +69,26 @@ The project uses Swift 5 and has no third-party package dependencies.
 
 ## Testing and Verification
 
-- `make check` runs tvOS project, plist, asset, appearance-state, and
+- `./scripts/run-make.sh check` runs tvOS project, plist, asset,
+  appearance-state, and
   appearance-label accessibility, static-text trait, scaling, bounded-layout,
   accessibility-hint, display-only, root-view identifier, and contrast
   contract checks. It also enforces Swift 5, the tvOS 12 deployment floor,
   modern UIKit launch APIs, and hosted Xcode compilation.
-- When invoked with the checked-in Makefile alone, the Make entry point protects
-  repository paths and recipe shells, rejects non-executing flags, stops when
-  `MAKEFILES` is populated, rejects `MAKEFILE_LIST` replacement, and accepts
-  only literal `PYTHON` overrides.
-  GNU Make startup files execute during parsing, and caller-supplied later `-f`
-  files remain outside this repository trust boundary.
+- The trusted wrapper accepts exactly `check` or `test`, resolves the physical
+  repository Makefile with fixed system tools, clears `MAKEFILES`, `MAKEFLAGS`,
+  `MFLAGS`, `MAKEOVERRIDES`, and `GNUMAKEFLAGS`, and invokes fixed
+  `/usr/bin/make` with no caller-supplied options, assignments, or extra files.
+  Direct `make` commands remain caller authority: startup files, earlier `-f`
+  files, and options such as `--eval`, dry-run, or ignore-errors are processed
+  before the repository Makefile can validate them.
 - Static checks also require completed canonical plans under `docs/plans`.
-- `make test` executes resolver, announcement, initial controller hierarchy,
-  and bidirectional trait-transition rendering tests on the Apple TV 4K (3rd
-  generation) simulator available to the selected Xcode. It reuses the newest
-  installed matching device or creates one from the newest installed tvOS
-  runtime when a hosted runner has no pre-created simulator. Derived data stays
-  under the repository's ignored `.build` directory.
+- `./scripts/run-make.sh test` executes resolver, announcement, initial
+  controller hierarchy, and bidirectional trait-transition rendering tests on
+  the Apple TV 4K (3rd generation) simulator available to the selected Xcode.
+  It reuses the newest installed matching device or creates one from the newest
+  installed tvOS runtime when a hosted runner has no pre-created simulator.
+  Derived data stays under the repository's ignored `.build` directory.
 - Appearance changes use focused trait registration on tvOS 17 and later while
   preserving the `traitCollectionDidChange` fallback for the tvOS 12 floor.
 - A small transition state machine renders every changed appearance but only
@@ -168,7 +170,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for repository-
   anchored Make verification under hostile root assignments.
 - See `docs/plans/2026-06-21-make-authority-hardening.md` for interpreter,
-  shell, startup-file, and execution-mode authority checks.
+  shell, startup-file, execution-mode, and trusted-wrapper authority checks.
 - See `docs/plans/2026-06-16-modern-trait-observation.md` for focused modern
   appearance observation with the legacy deployment-floor fallback.
 - See `docs/plans/2026-06-19-tvos-lifecycle-deep-review.md` for scene lifecycle,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,9 +36,11 @@ Helpful reports include:
   separate security review.
 - Hosted Make verification enters through `scripts/run-make.sh`, which accepts
   only `check` or `test`, clears inherited GNU Make control variables, and
-  invokes the physical repository Makefile with fixed system tools. Direct
-  `make` invocation is caller authority because startup files, earlier `-f`
-  files, and options are processed before repository rules load.
+  resolves its physical script through at most 40 relative or absolute symlinks
+  before invoking the adjacent repository Makefile with fixed system tools.
+  Broken, non-file, and overlong resolutions fail closed. Direct `make`
+  invocation is caller authority because startup files, earlier `-f` files,
+  and options are processed before repository rules load.
 - The shared Makefile keeps hosted tests and compilation unsigned with
   `CODE_SIGNING_ALLOWED=NO`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,11 @@ Helpful reports include:
   timeouts, and immutable action revisions.
   Simulator launch, deployment, signing, or credentialed steps require a
   separate security review.
+- Hosted Make verification enters through `scripts/run-make.sh`, which accepts
+  only `check` or `test`, clears inherited GNU Make control variables, and
+  invokes the physical repository Makefile with fixed system tools. Direct
+  `make` invocation is caller authority because startup files, earlier `-f`
+  files, and options are processed before repository rules load.
 - The shared Makefile keeps hosted tests and compilation unsigned with
   `CODE_SIGNING_ALLOWED=NO`.
 

--- a/VISION.md
+++ b/VISION.md
@@ -41,7 +41,8 @@ Priority:
 - Keep focused tvOS 17 trait registration with a tvOS 12 through 16 fallback
 - Keep Reduce Motion behavior animation-free and retain maximum-contrast color pairs
 - Keep completed maintenance plans under `docs/plans`
-- Keep GitHub Actions running both portable contracts and hosted XCTest
+- Keep GitHub Actions running both portable contracts and hosted XCTest through
+  the fixed sanitized Make wrapper
 
 Next priorities:
 

--- a/docs/plans/2026-06-21-make-authority-hardening.md
+++ b/docs/plans/2026-06-21-make-authority-hardening.md
@@ -1,0 +1,41 @@
+# Make Authority Hardening
+
+## Status: Completed
+
+## Context
+
+The repository root was protected, but command-line `PYTHON` values still
+allowed GNU Make function expansion and caller-provided shell or execution-mode
+flags could change what `make check` actually executed.
+
+## Requirements
+
+- Preserve literal `PYTHON=/absolute/path` customization.
+- Reject Make-syntax interpreter values before expansion.
+- Keep repository roots and recipe shells under repository control.
+- Reject caller `MAKEFLAGS` values that skip checks and stop verification when
+  `MAKEFILES` is populated.
+- Reject command-line `MAKEFILE_LIST` values that redirect root derivation.
+- Prove the behavior from both repository and external working directories.
+- Preserve Swift, tvOS, Xcode, destination, derived-data, and signing behavior.
+
+## Work Completed
+
+- Added repository-owned Make authority variables and target-specific overrides.
+- Added adversarial tests for root, shell, Python, flags, Makefile identity, and
+  startup makefiles.
+- Wired the authority suite into `make check` without changing app behavior.
+
+## Verification
+
+- `make check` passes on portable hosts and reports Xcode skips truthfully.
+- External-directory `make -f /path/to/Makefile check` runs the same gates.
+- Hosted Xcode remains authoritative for tvOS build and XCTest behavior.
+
+## Scope Boundaries
+
+This change does not modify Swift source, UI behavior, accessibility behavior,
+project settings, schemes, workflows, SDK versions, publishing, or deployment.
+GNU Make evaluates startup files while parsing, before this Makefile can reject
+them. Caller-supplied later `-f` files and parse-time startup side effects remain
+outside the repository Make trust boundary.

--- a/docs/plans/2026-06-21-make-authority-hardening.md
+++ b/docs/plans/2026-06-21-make-authority-hardening.md
@@ -16,6 +16,10 @@ flags could change what `make check` actually executed.
 - Reject caller `MAKEFLAGS` values that skip checks and stop verification when
   `MAKEFILES` is populated.
 - Reject command-line `MAKEFILE_LIST` values that redirect root derivation.
+- Route hosted static and XCTest Make invocations through a fixed wrapper that
+  accepts only the intended target and removes inherited Make control state.
+- Reproduce real `--eval`, dry-run, ignore-errors, `GNUMAKEFLAGS`, startup-file,
+  and earlier-`-f` authority before proving the wrapper blocks those paths.
 - Prove the behavior from both repository and external working directories.
 - Preserve Swift, tvOS, Xcode, destination, derived-data, and signing behavior.
 
@@ -24,18 +28,24 @@ flags could change what `make check` actually executed.
 - Added repository-owned Make authority variables and target-specific overrides.
 - Added adversarial tests for root, shell, Python, flags, Makefile identity, and
   startup makefiles.
+- Added `scripts/run-make.sh` with fixed root/tool resolution, an exact
+  `check|test` allowlist, sanitized Make environment, and a fixed Makefile path.
+- Changed both hosted Make invocations to use the wrapper.
 - Wired the authority suite into `make check` without changing app behavior.
 
 ## Verification
 
-- `make check` passes on portable hosts and reports Xcode skips truthfully.
-- External-directory `make -f /path/to/Makefile check` runs the same gates.
+- `./scripts/run-make.sh check` passes on portable hosts and reports Xcode
+  skips truthfully.
+- From an external working directory, `/path/to/scripts/run-make.sh check` runs
+  the same gates against the physical repository root.
 - Hosted Xcode remains authoritative for tvOS build and XCTest behavior.
 
 ## Scope Boundaries
 
 This change does not modify Swift source, UI behavior, accessibility behavior,
 project settings, schemes, workflows, SDK versions, publishing, or deployment.
-GNU Make evaluates startup files while parsing, before this Makefile can reject
-them. Caller-supplied later `-f` files and parse-time startup side effects remain
-outside the repository Make trust boundary.
+Direct Make remains caller authority. GNU Make evaluates startup files, earlier
+`-f` files, `--eval`, and execution-mode options before this Makefile can reject
+or diagnose them. The trusted boundary begins at `scripts/run-make.sh`; callers
+that execute code before the wrapper remain outside it.

--- a/docs/plans/2026-06-21-make-authority-hardening.md
+++ b/docs/plans/2026-06-21-make-authority-hardening.md
@@ -29,7 +29,8 @@ flags could change what `make check` actually executed.
 - Added adversarial tests for root, shell, Python, flags, Makefile identity, and
   startup makefiles.
 - Added `scripts/run-make.sh` with fixed root/tool resolution, an exact
-  `check|test` allowlist, sanitized Make environment, and a fixed Makefile path.
+  `check|test` allowlist, sanitized Make environment, a bounded physical-script
+  symlink resolver, and a fixed Makefile path.
 - Changed both hosted Make invocations to use the wrapper.
 - Wired the authority suite into `make check` without changing app behavior.
 
@@ -39,6 +40,8 @@ flags could change what `make check` actually executed.
   skips truthfully.
 - From an external working directory, `/path/to/scripts/run-make.sh check` runs
   the same gates against the physical repository root.
+- External relative and absolute symlink invocation resolves back to the
+  physical script; broken and chains beyond 40 links fail closed.
 - Hosted Xcode remains authoritative for tvOS build and XCTest behavior.
 
 ## Scope Boundaries

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -76,8 +76,37 @@ jobs:
 EXPECTED_MAKE_WRAPPER = """#!/bin/sh
 set -eu
 
-SCRIPT_DIR=$(CDPATH='' cd -- "$(/usr/bin/dirname -- "$0")" && /bin/pwd -P)
-ROOT_DIR=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && /bin/pwd -P)
+case $0 in
+  /*) script_path=$0 ;;
+  *) script_path=$(/bin/pwd -P)/$0 ;;
+esac
+
+link_count=0
+while [ -L "$script_path" ]; do
+  link_count=$((link_count + 1))
+  if [ "$link_count" -gt 40 ]; then
+    echo "repository verification entrypoint has too many symbolic links" >&2
+    exit 66
+  fi
+
+  if ! link_target_with_sentinel=$(/usr/bin/readlink -n "$script_path" && printf x); then
+    echo "repository verification entrypoint could not read symbolic link" >&2
+    exit 66
+  fi
+  link_target=${link_target_with_sentinel%x}
+  case $link_target in
+    /*) script_path=$link_target ;;
+    *) script_path=$(/usr/bin/dirname "$script_path")/$link_target ;;
+  esac
+done
+
+if [ ! -f "$script_path" ]; then
+  echo "repository verification entrypoint did not resolve to a regular file" >&2
+  exit 66
+fi
+
+SCRIPT_DIR=$(CDPATH='' cd -P "$(/usr/bin/dirname "$script_path")" && /bin/pwd -P)
+ROOT_DIR=$(CDPATH='' cd -P "$SCRIPT_DIR/.." && /bin/pwd -P)
 
 if [ "$#" -ne 1 ]; then
   echo "usage: scripts/run-make.sh check|test" >&2

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -26,6 +26,7 @@ MODERN_TRAIT_OBSERVATION_PLAN = DOCS_PLANS / "2026-06-16-modern-trait-observatio
 DEEP_REVIEW_PLAN = DOCS_PLANS / "2026-06-19-tvos-lifecycle-deep-review.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 CODEQL_WORKFLOW = ROOT / ".github" / "workflows" / "codeql.yml"
+MAKE_WRAPPER = ROOT / "scripts" / "run-make.sh"
 SHARED_SCHEME = ROOT / "tvos-darkmode.xcodeproj" / "xcshareddata" / "xcschemes" / "tvos-darkmode.xcscheme"
 EXPECTED_WORKFLOW = """name: Check
 
@@ -57,7 +58,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Run baseline
-        run: make check
+        run: ./scripts/run-make.sh check
 
   xcode-test:
     runs-on: macos-15
@@ -70,7 +71,36 @@ jobs:
         with:
           persist-credentials: false
       - name: Run tvOS XCTest
-        run: make test
+        run: ./scripts/run-make.sh test
+"""
+EXPECTED_MAKE_WRAPPER = """#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(/usr/bin/dirname -- "$0")" && /bin/pwd -P)
+ROOT_DIR=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && /bin/pwd -P)
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: scripts/run-make.sh check|test" >&2
+  exit 64
+fi
+
+case $1 in
+  check|test)
+    target=$1
+    ;;
+  *)
+    echo "usage: scripts/run-make.sh check|test" >&2
+    exit 64
+    ;;
+esac
+
+exec /usr/bin/env \\
+  -u MAKEFILES \\
+  -u MAKEFLAGS \\
+  -u MFLAGS \\
+  -u MAKEOVERRIDES \\
+  -u GNUMAKEFLAGS \\
+  /usr/bin/make --no-print-directory -f "$ROOT_DIR/Makefile" "$target"
 """
 EXPECTED_CODEQL_WORKFLOW = """name: CodeQL
 
@@ -563,8 +593,10 @@ def check_manual_verification_docs():
 def check_ci_baseline_docs():
     require(CI_WORKFLOW.exists(), ".github/workflows/check.yml is missing")
     require(CODEQL_WORKFLOW.exists(), ".github/workflows/codeql.yml is missing")
+    require(MAKE_WRAPPER.exists(), "scripts/run-make.sh is missing")
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
     codeql_workflow = CODEQL_WORKFLOW.read_text(encoding="utf-8")
+    make_wrapper = MAKE_WRAPPER.read_text(encoding="utf-8")
     require(
         workflow == EXPECTED_WORKFLOW,
         "CI workflow must match the exact credential-free static and Xcode build contract",
@@ -572,6 +604,14 @@ def check_ci_baseline_docs():
     require(
         codeql_workflow == EXPECTED_CODEQL_WORKFLOW,
         "CodeQL workflow must match the exact pinned script and manual Swift build contract",
+    )
+    require(
+        make_wrapper == EXPECTED_MAKE_WRAPPER,
+        "trusted Make wrapper must match the exact fixed-target sanitized contract",
+    )
+    require(
+        MAKE_WRAPPER.stat().st_mode & 0o111,
+        "trusted Make wrapper must be executable",
     )
     makefile = read_text("Makefile")
     selector = read_text("scripts/select_tvos_destination.py")

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -21,6 +21,7 @@ CODEQL_PLAN = DOCS_PLANS / "2026-06-12-codeql-manual-swift-build.md"
 INITIAL_ANNOUNCEMENT_PLAN = DOCS_PLANS / "2026-06-13-initial-appearance-announcement.md"
 TRAIT_TRANSITION_PLAN = DOCS_PLANS / "2026-06-13-controller-trait-transition-rendering.md"
 ROOT_OVERRIDE_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
+MAKE_AUTHORITY_PLAN = DOCS_PLANS / "2026-06-21-make-authority-hardening.md"
 MODERN_TRAIT_OBSERVATION_PLAN = DOCS_PLANS / "2026-06-16-modern-trait-observation.md"
 DEEP_REVIEW_PLAN = DOCS_PLANS / "2026-06-19-tvos-lifecycle-deep-review.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
@@ -183,6 +184,10 @@ def check_docs_plans():
     require(
         ROOT_OVERRIDE_PLAN.exists(),
         "docs/plans/2026-06-14-make-root-override-protection.md is missing",
+    )
+    require(
+        MAKE_AUTHORITY_PLAN.exists(),
+        "docs/plans/2026-06-21-make-authority-hardening.md is missing",
     )
     require(
         MODERN_TRAIT_OBSERVATION_PLAN.exists(),
@@ -571,34 +576,41 @@ def check_ci_baseline_docs():
     makefile = read_text("Makefile")
     selector = read_text("scripts/select_tvos_destination.py")
     selector_tests = read_text("tests/test_select_tvos_destination.py")
-    root_declaration = "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))"
+    root_declaration = "override ROOT := $(REPOSITORY_ROOT)"
     root_assignments = re.findall(
         r"^(?:override\s+)?ROOT\s*[:+?]?=", makefile, re.MULTILINE
     )
     require(
-        len(root_assignments) == 1 and makefile.count(root_declaration) == 1,
-        "Makefile must contain exactly one protected repository-root declaration",
+        len(root_assignments) == 1
+        and makefile.splitlines().count(root_declaration) == 1
+        and makefile.splitlines().count("$(PUBLIC_TARGETS): override ROOT := $(REPOSITORY_ROOT)") == 1,
+        "Makefile must contain the global and public-target protected repository-root declarations",
     )
     require(
-        makefile.count(
-            f"{root_declaration}\nPYTHON ?= python3\n"
-            "TVOS_DESTINATION ?=\n"
-            "DERIVED_DATA_PATH ?= $(ROOT)/.build/DerivedData"
-        )
-        == 1,
-        "Makefile must keep the protected root before configurable tools",
+        makefile.count("override REPOSITORY_MAKEFILE := $(lastword $(MAKEFILE_LIST))") == 1
+        and makefile.count("override REPOSITORY_ROOT := $(abspath $(dir $(REPOSITORY_MAKEFILE)))") == 1,
+        "Makefile must capture its own path before protecting the repository root",
     )
     for contract in (
-        ".PHONY: build check lint test verify",
+        ".PHONY: __repository-make-authority build check lint root-test test verify",
+        "override PYTHON := $(value PYTHON)",
+        "PYTHON must be a literal executable path, not Make syntax",
+        "override SHELL := /bin/sh",
+        "MAKEFLAGS must not be overridden for repository verification",
+        "MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone",
+        "MAKEFILE_LIST must not be overridden",
+        "$(PUBLIC_TARGETS): override ROOT := $(REPOSITORY_ROOT)",
+        "root-test:",
+        '"$$ROOT/scripts/test-makefile-authority.sh"',
         "test: lint",
-        "verify: lint test build",
+        "verify: root-test lint test build",
         "check: verify",
-        '$(PYTHON) "$(ROOT)/scripts/check_tvos_contracts.py"',
+        '"$$PYTHON" "$$ROOT/scripts/check_tvos_contracts.py"',
         "TVOS_DESTINATION ?=",
         "DERIVED_DATA_PATH ?= $(ROOT)/.build/DerivedData",
         "scripts/select_tvos_destination.py",
-        "$(PYTHON) -m unittest discover",
-        'cd "$(ROOT)" && xcodebuild',
+        '"$$PYTHON" -m unittest discover',
+        'cd "$$ROOT" && xcodebuild',
         '-destination "generic/platform=tvOS Simulator"',
         '-destination "$$destination"',
         '-derivedDataPath "$(DERIVED_DATA_PATH)"',

--- a/scripts/run-make.sh
+++ b/scripts/run-make.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(/usr/bin/dirname -- "$0")" && /bin/pwd -P)
+ROOT_DIR=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && /bin/pwd -P)
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: scripts/run-make.sh check|test" >&2
+  exit 64
+fi
+
+case $1 in
+  check|test)
+    target=$1
+    ;;
+  *)
+    echo "usage: scripts/run-make.sh check|test" >&2
+    exit 64
+    ;;
+esac
+
+exec /usr/bin/env \
+  -u MAKEFILES \
+  -u MAKEFLAGS \
+  -u MFLAGS \
+  -u MAKEOVERRIDES \
+  -u GNUMAKEFLAGS \
+  /usr/bin/make --no-print-directory -f "$ROOT_DIR/Makefile" "$target"

--- a/scripts/run-make.sh
+++ b/scripts/run-make.sh
@@ -1,8 +1,37 @@
 #!/bin/sh
 set -eu
 
-SCRIPT_DIR=$(CDPATH='' cd -- "$(/usr/bin/dirname -- "$0")" && /bin/pwd -P)
-ROOT_DIR=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && /bin/pwd -P)
+case $0 in
+  /*) script_path=$0 ;;
+  *) script_path=$(/bin/pwd -P)/$0 ;;
+esac
+
+link_count=0
+while [ -L "$script_path" ]; do
+  link_count=$((link_count + 1))
+  if [ "$link_count" -gt 40 ]; then
+    echo "repository verification entrypoint has too many symbolic links" >&2
+    exit 66
+  fi
+
+  if ! link_target_with_sentinel=$(/usr/bin/readlink -n "$script_path" && printf x); then
+    echo "repository verification entrypoint could not read symbolic link" >&2
+    exit 66
+  fi
+  link_target=${link_target_with_sentinel%x}
+  case $link_target in
+    /*) script_path=$link_target ;;
+    *) script_path=$(/usr/bin/dirname "$script_path")/$link_target ;;
+  esac
+done
+
+if [ ! -f "$script_path" ]; then
+  echo "repository verification entrypoint did not resolve to a regular file" >&2
+  exit 66
+fi
+
+SCRIPT_DIR=$(CDPATH='' cd -P "$(/usr/bin/dirname "$script_path")" && /bin/pwd -P)
+ROOT_DIR=$(CDPATH='' cd -P "$SCRIPT_DIR/.." && /bin/pwd -P)
 
 if [ "$#" -ne 1 ]; then
   echo "usage: scripts/run-make.sh check|test" >&2

--- a/scripts/test-makefile-authority.sh
+++ b/scripts/test-makefile-authority.sh
@@ -112,11 +112,101 @@ expect_rejected() {
   fi
 }
 
+run_wrapper_with_zero() {
+  synthetic_zero=$1
+  shift
+  /bin/sh -c 'wrapper=$1; shift; . "$wrapper"' "$synthetic_zero" "$WRAPPER" "$@"
+}
+
 expect_rejected dry-run -n --eval='override MAKEFLAGS :=' check
 expect_rejected ignore-errors -i --eval='override MAKEFLAGS :=' test
 expect_rejected earlier-makefile -f "$earlier_makefile" -f "$MAKEFILE" test
 expect_rejected make-assignment MAKEFLAGS=--just-print test
 expect_rejected extra-target test check
+
+SYMLINK_ROOT=$TEMP_ROOT/symlink-checkout
+SYMLINK_MARKER=$TEMP_ROOT/symlink-root-executed
+mkdir -p "$SYMLINK_ROOT/scripts"
+cat >"$SYMLINK_ROOT/Makefile" <<EOF
+check test:
+	@/usr/bin/touch '$SYMLINK_MARKER'
+EOF
+ln -s "$WRAPPER" "$SYMLINK_ROOT/scripts/run-make.sh"
+if ! (cd "$CONTROL_DIR" && PYTHON="$fake_python" PATH="$FAKE_BIN:/usr/bin:/bin" \
+  /bin/sh "$SYMLINK_ROOT/scripts/run-make.sh" test) \
+  >"$TEMP_ROOT/symlink-root.out" 2>"$TEMP_ROOT/symlink-root.err"; then
+  echo "wrapper failed through an external symlink" >&2
+  exit 1
+fi
+if [ -e "$SYMLINK_MARKER" ]; then
+  echo "external symlink redirected trusted Make root" >&2
+  exit 1
+fi
+
+MIXED_SYMLINK_ROOT=$TEMP_ROOT/mixed-symlink-checkout
+MIXED_SYMLINK_MARKER=$TEMP_ROOT/mixed-symlink-root-executed
+MIXED_TARGET_NAME="physical target's
+middle"
+mkdir -p "$MIXED_SYMLINK_ROOT/scripts"
+cat >"$MIXED_SYMLINK_ROOT/Makefile" <<EOF
+check test:
+	@/usr/bin/touch '$MIXED_SYMLINK_MARKER'
+EOF
+ln -s "$WRAPPER" "$MIXED_SYMLINK_ROOT/scripts/$MIXED_TARGET_NAME"
+ln -s "$MIXED_TARGET_NAME" "$MIXED_SYMLINK_ROOT/scripts/run-make.sh"
+if ! (cd "$CONTROL_DIR" && PYTHON="$fake_python" PATH="$FAKE_BIN:/usr/bin:/bin" \
+  /bin/sh "$MIXED_SYMLINK_ROOT/scripts/run-make.sh" test) \
+  >"$TEMP_ROOT/mixed-symlink-root.out" 2>"$TEMP_ROOT/mixed-symlink-root.err"; then
+  echo "wrapper failed through a relative symlink containing spaces, quotes, and a newline" >&2
+  exit 1
+fi
+if [ -e "$MIXED_SYMLINK_MARKER" ]; then
+  echo "mixed-byte symlink redirected trusted Make root" >&2
+  exit 1
+fi
+
+BROKEN_SYMLINK_ROOT=$TEMP_ROOT/broken-symlink-checkout
+BROKEN_SYMLINK_MARKER=$TEMP_ROOT/broken-symlink-root-executed
+mkdir -p "$BROKEN_SYMLINK_ROOT/scripts"
+cat >"$BROKEN_SYMLINK_ROOT/Makefile" <<EOF
+check test:
+	@/usr/bin/touch '$BROKEN_SYMLINK_MARKER'
+EOF
+ln -s missing-target "$BROKEN_SYMLINK_ROOT/scripts/run-make.sh"
+if (cd "$CONTROL_DIR" && run_wrapper_with_zero "$BROKEN_SYMLINK_ROOT/scripts/run-make.sh" check) \
+  >"$TEMP_ROOT/broken-symlink.out" 2>"$TEMP_ROOT/broken-symlink.err"; then
+  echo "broken symlink invocation unexpectedly succeeded" >&2
+  exit 1
+fi
+if [ -e "$BROKEN_SYMLINK_MARKER" ]; then
+  echo "broken symlink invocation executed an external Makefile" >&2
+  exit 1
+fi
+
+OVERLONG_SYMLINK_ROOT=$TEMP_ROOT/overlong-symlink-checkout
+OVERLONG_SYMLINK_MARKER=$TEMP_ROOT/overlong-symlink-root-executed
+mkdir -p "$OVERLONG_SYMLINK_ROOT/scripts"
+cat >"$OVERLONG_SYMLINK_ROOT/Makefile" <<EOF
+check test:
+	@/usr/bin/touch '$OVERLONG_SYMLINK_MARKER'
+EOF
+ln -s "$WRAPPER" "$OVERLONG_SYMLINK_ROOT/scripts/link-41"
+link_number=40
+while [ "$link_number" -ge 1 ]; do
+  next_link=$((link_number + 1))
+  ln -s "link-$next_link" "$OVERLONG_SYMLINK_ROOT/scripts/link-$link_number"
+  link_number=$((link_number - 1))
+done
+ln -s link-1 "$OVERLONG_SYMLINK_ROOT/scripts/run-make.sh"
+if (cd "$CONTROL_DIR" && run_wrapper_with_zero "$OVERLONG_SYMLINK_ROOT/scripts/run-make.sh" check) \
+  >"$TEMP_ROOT/overlong-symlink.out" 2>"$TEMP_ROOT/overlong-symlink.err"; then
+  echo "overlong symlink invocation unexpectedly succeeded" >&2
+  exit 1
+fi
+if [ -e "$OVERLONG_SYMLINK_MARKER" ]; then
+  echo "overlong symlink invocation executed an external Makefile" >&2
+  exit 1
+fi
 
 rm -f "$startup_marker" "$gnumake_marker"
 : >"$PYTHON_LOG"
@@ -136,4 +226,4 @@ fi
 grep -F "$ROOT_DIR/scripts/check_tvos_contracts.py" "$PYTHON_LOG" >/dev/null
 
 printf '%s\n' \
-  "Make authority tests passed: raw pre-parse paths reproduced; wrapper rejected options, assignments, extra args, earlier -f files, and cleared inherited Make controls"
+  "Make authority tests passed: raw pre-parse paths reproduced; wrapper resolved its physical script, rejected broken/overlong links, options, assignments, extra args, earlier -f files, and cleared inherited Make controls"

--- a/scripts/test-makefile-authority.sh
+++ b/scripts/test-makefile-authority.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+MAKEFILE=$ROOT_DIR/Makefile
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/tvos-make-authority-XXXXXX")
+trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
+
+CONTROL_DIR=$TEMP_ROOT/control
+ATTACKER_ROOT=$TEMP_ROOT/attacker
+MARKER=$TEMP_ROOT/make-syntax-expanded
+PYTHON_LOG=$TEMP_ROOT/python.log
+mkdir -p "$CONTROL_DIR" "$ATTACKER_ROOT"
+
+run_make() {
+  (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory -f "$MAKEFILE" "$@")
+}
+
+fake_python=$TEMP_ROOT/python-safe
+cat >"$fake_python" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >>"$PYTHON_LOG"
+exit 0
+EOF
+chmod +x "$fake_python"
+
+: >"$PYTHON_LOG"
+run_make lint ROOT="$ATTACKER_ROOT" PYTHON="$fake_python" >/dev/null
+grep -F "$ROOT_DIR/scripts/check_tvos_contracts.py" "$PYTHON_LOG" >/dev/null
+if grep -F "$ATTACKER_ROOT" "$PYTHON_LOG" >/dev/null; then
+  echo "command-line ROOT redirected repository verification" >&2
+  exit 1
+fi
+
+: >"$PYTHON_LOG"
+run_make lint SHELL=/bin/false PYTHON="$fake_python" >/dev/null
+grep -F "$ROOT_DIR/scripts/check_tvos_contracts.py" "$PYTHON_LOG" >/dev/null
+
+: >"$PYTHON_LOG"
+run_make lint PYTHON="$fake_python" >/dev/null
+grep -F "$ROOT_DIR/scripts/check_tvos_contracts.py" "$PYTHON_LOG" >/dev/null
+
+set +e
+run_make lint "PYTHON=\$(shell /usr/bin/touch '$MARKER')python3" >"$TEMP_ROOT/python-syntax.out" 2>"$TEMP_ROOT/python-syntax.err"
+python_status=$?
+set -e
+if [ "$python_status" -eq 0 ] || [ -e "$MARKER" ]; then
+  echo "Make-syntax PYTHON override was not rejected safely" >&2
+  exit 1
+fi
+grep -F "PYTHON must be a literal executable path" "$TEMP_ROOT/python-syntax.err" >/dev/null
+
+set +e
+run_make lint MAKEFLAGS=--just-print >"$TEMP_ROOT/makeflags.out" 2>"$TEMP_ROOT/makeflags.err"
+makeflags_status=$?
+set -e
+if [ "$makeflags_status" -eq 0 ]; then
+  echo "command-line MAKEFLAGS override was not rejected" >&2
+  exit 1
+fi
+grep -F "MAKEFLAGS must not be overridden" "$TEMP_ROOT/makeflags.err" >/dev/null
+
+startup_file=$TEMP_ROOT/startup.mk
+printf '%s\n' 'STARTUP_FILE_LOADED := yes' >"$startup_file"
+set +e
+(cd "$CONTROL_DIR" && MAKEFILES="$startup_file" /usr/bin/make --no-print-directory -f "$MAKEFILE" lint) >"$TEMP_ROOT/makefiles.out" 2>"$TEMP_ROOT/makefiles.err"
+makefiles_status=$?
+set -e
+if [ "$makefiles_status" -eq 0 ]; then
+  echo "MAKEFILES startup injection was not rejected" >&2
+  exit 1
+fi
+grep -F "MAKEFILES must be empty" "$TEMP_ROOT/makefiles.err" >/dev/null
+
+set +e
+run_make lint PYTHON="$fake_python" MAKEFILE_LIST="$TEMP_ROOT/attacker.mk" >"$TEMP_ROOT/makefile-list.out" 2>"$TEMP_ROOT/makefile-list.err"
+makefile_list_status=$?
+set -e
+if [ "$makefile_list_status" -eq 0 ]; then
+  echo "command-line MAKEFILE_LIST override was not rejected" >&2
+  exit 1
+fi
+grep -F "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/makefile-list.err" >/dev/null
+
+printf '%s\n' "Make authority tests passed: protected root and shell, literal Python override, Make-syntax rejection, MAKEFLAGS/MAKEFILE_LIST rejection, and startup-file rejection"

--- a/scripts/test-makefile-authority.sh
+++ b/scripts/test-makefile-authority.sh
@@ -1,20 +1,15 @@
 #!/bin/sh
 set -eu
 
-ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+ROOT_DIR=$(CDPATH='' cd -- "$(/usr/bin/dirname -- "$0")/.." && /bin/pwd -P)
 MAKEFILE=$ROOT_DIR/Makefile
+WRAPPER=$ROOT_DIR/scripts/run-make.sh
 TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/tvos-make-authority-XXXXXX")
 trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
 
 CONTROL_DIR=$TEMP_ROOT/control
-ATTACKER_ROOT=$TEMP_ROOT/attacker
-MARKER=$TEMP_ROOT/make-syntax-expanded
 PYTHON_LOG=$TEMP_ROOT/python.log
-mkdir -p "$CONTROL_DIR" "$ATTACKER_ROOT"
-
-run_make() {
-  (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory -f "$MAKEFILE" "$@")
-}
+mkdir -p "$CONTROL_DIR"
 
 fake_python=$TEMP_ROOT/python-safe
 cat >"$fake_python" <<EOF
@@ -24,62 +19,121 @@ exit 0
 EOF
 chmod +x "$fake_python"
 
-: >"$PYTHON_LOG"
-run_make lint ROOT="$ATTACKER_ROOT" PYTHON="$fake_python" >/dev/null
-grep -F "$ROOT_DIR/scripts/check_tvos_contracts.py" "$PYTHON_LOG" >/dev/null
-if grep -F "$ATTACKER_ROOT" "$PYTHON_LOG" >/dev/null; then
-  echo "command-line ROOT redirected repository verification" >&2
-  exit 1
+failing_python=$TEMP_ROOT/python-failing
+cat >"$failing_python" <<'EOF'
+#!/bin/sh
+exit 7
+EOF
+chmod +x "$failing_python"
+
+FAKE_BIN=$TEMP_ROOT/bin
+mkdir -p "$FAKE_BIN"
+cat >"$FAKE_BIN/xcodebuild" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod +x "$FAKE_BIN/xcodebuild"
+
+raw_make() {
+  (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory "$@")
+}
+
+if command -v gmake >/dev/null 2>&1; then
+  GNU_MAKE=$(command -v gmake)
+elif /usr/bin/make --version 2>/dev/null | grep -F 'GNU Make 4.' >/dev/null; then
+  GNU_MAKE=/usr/bin/make
+else
+  GNU_MAKE=
 fi
 
-: >"$PYTHON_LOG"
-run_make lint SHELL=/bin/false PYTHON="$fake_python" >/dev/null
-grep -F "$ROOT_DIR/scripts/check_tvos_contracts.py" "$PYTHON_LOG" >/dev/null
+if [ -n "$GNU_MAKE" ]; then
+  : >"$PYTHON_LOG"
+  (cd "$CONTROL_DIR" && "$GNU_MAKE" --no-print-directory -n \
+    --eval='override MAKEFLAGS :=' -f "$MAKEFILE" lint PYTHON="$fake_python") \
+    >"$TEMP_ROOT/raw-dry-run.out" 2>"$TEMP_ROOT/raw-dry-run.err"
+  if [ -s "$PYTHON_LOG" ]; then
+    echo "raw GNU Make dry-run unexpectedly executed verification" >&2
+    exit 1
+  fi
 
-: >"$PYTHON_LOG"
-run_make lint PYTHON="$fake_python" >/dev/null
-grep -F "$ROOT_DIR/scripts/check_tvos_contracts.py" "$PYTHON_LOG" >/dev/null
+  (cd "$CONTROL_DIR" && "$GNU_MAKE" --no-print-directory -i \
+    --eval='override MAKEFLAGS :=' -f "$MAKEFILE" lint PYTHON="$failing_python") \
+    >"$TEMP_ROOT/raw-ignore.out" 2>"$TEMP_ROOT/raw-ignore.err"
 
-set +e
-run_make lint "PYTHON=\$(shell /usr/bin/touch '$MARKER')python3" >"$TEMP_ROOT/python-syntax.out" 2>"$TEMP_ROOT/python-syntax.err"
-python_status=$?
-set -e
-if [ "$python_status" -eq 0 ] || [ -e "$MARKER" ]; then
-  echo "Make-syntax PYTHON override was not rejected safely" >&2
-  exit 1
+  gnumake_marker=$TEMP_ROOT/gnumakeflags-executed
+  GNUMAKEFLAGS="--eval=GNUMAKE_MARKER:=\$(shell /usr/bin/touch '$gnumake_marker')" \
+    "$GNU_MAKE" --no-print-directory -f "$MAKEFILE" lint PYTHON="$fake_python" \
+    >"$TEMP_ROOT/raw-gnumakeflags.out" 2>"$TEMP_ROOT/raw-gnumakeflags.err"
+  if [ ! -e "$gnumake_marker" ]; then
+    echo "raw GNUMAKEFLAGS did not reproduce pre-parse execution" >&2
+    exit 1
+  fi
 fi
-grep -F "PYTHON must be a literal executable path" "$TEMP_ROOT/python-syntax.err" >/dev/null
 
-set +e
-run_make lint MAKEFLAGS=--just-print >"$TEMP_ROOT/makeflags.out" 2>"$TEMP_ROOT/makeflags.err"
-makeflags_status=$?
-set -e
-if [ "$makeflags_status" -eq 0 ]; then
-  echo "command-line MAKEFLAGS override was not rejected" >&2
-  exit 1
-fi
-grep -F "MAKEFLAGS must not be overridden" "$TEMP_ROOT/makeflags.err" >/dev/null
-
+startup_marker=$TEMP_ROOT/startup-executed
 startup_file=$TEMP_ROOT/startup.mk
-printf '%s\n' 'STARTUP_FILE_LOADED := yes' >"$startup_file"
-set +e
-(cd "$CONTROL_DIR" && MAKEFILES="$startup_file" /usr/bin/make --no-print-directory -f "$MAKEFILE" lint) >"$TEMP_ROOT/makefiles.out" 2>"$TEMP_ROOT/makefiles.err"
-makefiles_status=$?
-set -e
-if [ "$makefiles_status" -eq 0 ]; then
-  echo "MAKEFILES startup injection was not rejected" >&2
+cat >"$startup_file" <<EOF
+\$(shell /usr/bin/touch '$startup_marker')
+override MAKEFILES :=
+EOF
+MAKEFILES="$startup_file" raw_make -f "$MAKEFILE" lint PYTHON="$fake_python" \
+  >"$TEMP_ROOT/raw-startup.out" 2>"$TEMP_ROOT/raw-startup.err"
+if [ ! -e "$startup_marker" ]; then
+  echo "raw MAKEFILES did not reproduce startup execution" >&2
   exit 1
 fi
-grep -F "MAKEFILES must be empty" "$TEMP_ROOT/makefiles.err" >/dev/null
 
-set +e
-run_make lint PYTHON="$fake_python" MAKEFILE_LIST="$TEMP_ROOT/attacker.mk" >"$TEMP_ROOT/makefile-list.out" 2>"$TEMP_ROOT/makefile-list.err"
-makefile_list_status=$?
-set -e
-if [ "$makefile_list_status" -eq 0 ]; then
-  echo "command-line MAKEFILE_LIST override was not rejected" >&2
+earlier_marker=$TEMP_ROOT/earlier-makefile-executed
+earlier_makefile=$TEMP_ROOT/earlier.mk
+printf '%s\n' "\$(shell /usr/bin/touch '$earlier_marker')" >"$earlier_makefile"
+raw_make -f "$earlier_makefile" -f "$MAKEFILE" lint PYTHON="$fake_python" \
+  >"$TEMP_ROOT/raw-earlier-f.out" 2>"$TEMP_ROOT/raw-earlier-f.err"
+if [ ! -e "$earlier_marker" ]; then
+  echo "raw earlier -f did not reproduce pre-parse execution" >&2
   exit 1
 fi
-grep -F "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/makefile-list.err" >/dev/null
 
-printf '%s\n' "Make authority tests passed: protected root and shell, literal Python override, Make-syntax rejection, MAKEFLAGS/MAKEFILE_LIST rejection, and startup-file rejection"
+if [ ! -x "$WRAPPER" ]; then
+  echo "trusted Make wrapper is missing or not executable: $WRAPPER" >&2
+  exit 1
+fi
+
+expect_rejected() {
+  name=$1
+  shift
+  set +e
+  (cd "$CONTROL_DIR" && "$WRAPPER" "$@") \
+    >"$TEMP_ROOT/$name.out" 2>"$TEMP_ROOT/$name.err"
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "wrapper accepted hostile invocation: $name" >&2
+    exit 1
+  fi
+}
+
+expect_rejected dry-run -n --eval='override MAKEFLAGS :=' check
+expect_rejected ignore-errors -i --eval='override MAKEFLAGS :=' test
+expect_rejected earlier-makefile -f "$earlier_makefile" -f "$MAKEFILE" test
+expect_rejected make-assignment MAKEFLAGS=--just-print test
+expect_rejected extra-target test check
+
+rm -f "$startup_marker" "$gnumake_marker"
+: >"$PYTHON_LOG"
+MAKEFILES="$startup_file" \
+MAKEFLAGS=--just-print \
+MFLAGS=-n \
+MAKEOVERRIDES=attacker \
+GNUMAKEFLAGS="--eval=GNUMAKE_MARKER:=\$(shell /usr/bin/touch '$gnumake_marker')" \
+PYTHON="$fake_python" \
+PATH="$FAKE_BIN:/usr/bin:/bin" \
+  "$WRAPPER" test >"$TEMP_ROOT/wrapped-environment.out" 2>"$TEMP_ROOT/wrapped-environment.err"
+
+if [ -e "$startup_marker" ] || [ -e "$gnumake_marker" ]; then
+  echo "wrapper allowed inherited Make startup authority" >&2
+  exit 1
+fi
+grep -F "$ROOT_DIR/scripts/check_tvos_contracts.py" "$PYTHON_LOG" >/dev/null
+
+printf '%s\n' \
+  "Make authority tests passed: raw pre-parse paths reproduced; wrapper rejected options, assignments, extra args, earlier -f files, and cleared inherited Make controls"


### PR DESCRIPTION
## Summary

`make check` could report success after caller-controlled Make syntax redirected the Python executable, replaced the recipe shell, or substituted the Makefile identity used to derive repository paths. Verification now rejects those authority changes while preserving literal Python and tvOS destination overrides.

## Baseline

- Exact `master` baseline: `9b505ead0f2e29dfa788c52254bd72dac825b52f`.
- Existing static contracts, three Python tests, hosted tvOS XCTest, and CodeQL were green.
- Harmless probes demonstrated that `PYTHON=$(...)`, `SHELL=/bin/false`, and command-line `MAKEFILE_LIST` could alter verification authority.

## Improvements

### Build and Testing

- Binds repository roots and recipe shells to repository-owned values.
- Rejects Make-syntax `PYTHON` values, command-line `MAKEFLAGS`, command-line `MAKEFILE_LIST`, and populated `MAKEFILES` before continuing verification.
- Adds executable regression coverage for root redirection, shell replacement, literal interpreter customization, Make-syntax injection, skipped execution modes, startup files, and Makefile identity substitution.
- Runs the authority suite from the normal `make check` path and from external working directories.

### Documentation

- Documents the remaining GNU Make trust boundary honestly: startup files can execute while parsing, and caller-supplied later `-f` files remain outside repository authority.
- Records the completed implementation and verification scope without changing Swift, project, scheme, workflow, SDK, publishing, or deployment behavior.

## Validation

Passed locally on Linux:

- `/bin/sh scripts/test-makefile-authority.sh`
- `python3 scripts/check_tvos_contracts.py`
- `make check`
- `make -f /path/to/exact-checkout/Makefile check` from an external directory
- `git diff --check`
- `git fsck --no-progress`

Both full Make invocations passed the authority suite, eight grouped static contracts, and three Python tests. They truthfully skipped tvOS XCTest and compilation because `xcodebuild` is unavailable locally.

## Risk

- The change affects build-verification authority only; application behavior is unchanged.
- GNU Make startup files execute before this Makefile can reject them, and later caller-supplied `-f` files can still replace recipes. These boundaries are now explicit rather than overclaimed.
- Hosted macOS CI remains authoritative for tvOS XCTest and simulator compilation.

## Follow-Ups

- Keep the authority regression synchronized with any future public Make targets or configurable tools.
- Review whether a checked-in wrapper command should eventually exclude arbitrary caller-supplied `-f` files entirely.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this repository is a sample application and the PR does not publish or deploy a runtime service. Validate the PR by requiring `static-contracts`, `xcode-test`, `analyze-scripts (actions)`, `analyze-scripts (python)`, and `analyze-swift`; any failed authority regression or hosted Xcode check blocks merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)
