### PR TITLE
test: export MAKEFILES through authority helper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,53 @@
 # Changes
 
+## 2026-06-24 23:37 PDT - P2 - Preserve raw MAKEFILES reproduction
+
+### Summary
+
+Exported the hostile `MAKEFILES` fixture before the authority helper invokes
+raw Make so the startup-file regression behaves consistently across POSIX
+shells.
+
+### Work completed
+
+- Wrapped the raw Make invocation in a subshell with exported `MAKEFILES`.
+- Preserved the existing proof that the trusted wrapper clears inherited Make
+  startup authority.
+
+### Threads
+
+- None. The focused shell fixture and existing hosted evidence were sufficient.
+
+### Files changed
+
+- `scripts/test-makefile-authority.sh` — exported the startup fixture through
+  the helper boundary.
+- `CHANGES.md` — recorded this maintenance cycle.
+
+### Validation
+
+- `/bin/sh scripts/test-makefile-authority.sh` — passed.
+- `make check` — static contracts and three host tests passed; local Xcode
+  build and XCTest skipped because `xcodebuild` is unavailable.
+- Hosted `xcode-test`, static contracts, and CodeQL — passed at PR head
+  `225e3ff`.
+- Codex review — clean with no accepted or actionable findings before this
+  documentation-only cycle record.
+
+### Bugs / findings
+
+- Temporary environment assignments are not required to propagate through
+  shell functions, so the prior fixture could silently omit `MAKEFILES`.
+
+### Blockers
+
+- None.
+
+### Next action
+
+- Rerun Codex review and hosted checks on the documented head, then merge PR
+  #11 if both remain clean.
+
 - Added a fixed `scripts/run-make.sh` entrypoint for hosted `check` and `test`
   runs. It clears inherited Make control variables, rejects options,
   assignments, extra targets, and alternate Makefiles, and invokes the physical

--- a/scripts/test-makefile-authority.sh
+++ b/scripts/test-makefile-authority.sh
@@ -76,8 +76,10 @@ cat >"$startup_file" <<EOF
 \$(shell /usr/bin/touch '$startup_marker')
 override MAKEFILES :=
 EOF
-MAKEFILES="$startup_file" raw_make -f "$MAKEFILE" lint PYTHON="$fake_python" \
-  >"$TEMP_ROOT/raw-startup.out" 2>"$TEMP_ROOT/raw-startup.err"
+(
+  export MAKEFILES="$startup_file"
+  raw_make -f "$MAKEFILE" lint PYTHON="$fake_python"
+) >"$TEMP_ROOT/raw-startup.out" 2>"$TEMP_ROOT/raw-startup.err"
 if [ ! -e "$startup_marker" ]; then
   echo "raw MAKEFILES did not reproduce startup execution" >&2
   exit 1


### PR DESCRIPTION
## Summary
- export the hostile `MAKEFILES` fixture before invoking the shell helper
- preserve the test's intent across POSIX shells where temporary assignments are not exported through functions

## Validation
- `/bin/sh scripts/test-makefile-authority.sh`
- `python3 -B scripts/check_tvos_contracts.py`
- `python3 -B -m unittest discover -s tests -p 'test_*.py'`

## Limitations
- Static and host-side contracts only; no Xcode, simulator, device, signing, or Apple service execution.
