### PR TITLE
Validate tvOS simulator identifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-tvos-darkmode-baseline.md` for the canonical appearance-state baseline.
 - See `docs/plans/2026-06-08-manual-appearance-verification.md` for the manual light/dark verification checklist.
+- Simulator selection must not emit blank or non-string UDIDs; skip malformed
+  discovered devices and fail closed on empty `simctl create` output.
 
 ## Agent workflow
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,33 @@
 # Changes
 
+## 2026-06-25 - P1 - Validate tvOS simulator identifiers
+
+### Summary
+
+Prevented the hosted XCTest destination selector from emitting blank simulator
+identifiers and deferring the failure into `xcodebuild`.
+
+### Work completed
+
+- Added shared normalization for discovered and newly created simulator UDIDs.
+- Skipped matching devices whose identifier is missing, non-string, or blank.
+- Rejected empty `simctl create` output with a stable selector error.
+- Added portable regression tests and mutation-sensitive static contracts.
+
+### Validation
+
+- Both focused blank-ID selector tests failed before implementation; the final
+  matrix also covers non-string discovered and created identifiers.
+- `make check` covers the selector suite and repository static contracts; real
+  simulator creation remains a hosted macOS gate.
+- A hostile normalization mutation that restored blank identifier acceptance
+  was rejected by both focused regressions.
+
+### Bugs / findings
+
+- P1: malformed simulator metadata could produce
+  `platform=tvOS Simulator,id=` and obscure the root cause in `xcodebuild`.
+
 ## 2026-06-24 23:37 PDT - P2 - Preserve raw MAKEFILES reproduction
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ The project uses Swift 5 and has no third-party package dependencies.
   the Apple TV 4K (3rd generation) simulator available to the selected Xcode.
   It reuses the newest installed matching device or creates one from the newest
   installed tvOS runtime when a hosted runner has no pre-created simulator.
+  Blank or non-string simulator identifiers are never emitted as destinations;
+  existing entries with malformed identifiers are skipped and malformed
+  creation output fails before `xcodebuild` starts.
   Derived data stays under the repository's ignored `.build` directory.
 - Appearance changes use focused trait registration on tvOS 17 and later while
   preserving the `traitCollectionDidChange` fallback for the tvOS 12 floor.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,9 @@ Helpful reports include:
   Broken, non-file, and overlong resolutions fail closed. Direct `make`
   invocation is caller authority because startup files, earlier `-f` files,
   and options are processed before repository rules load.
+- The tvOS destination selector accepts only non-empty string simulator UDIDs;
+  discovery entries with malformed identifiers are skipped and empty creation
+  output fails before constructing an `xcodebuild` destination.
 - The shared Makefile keeps hosted tests and compilation unsigned with
   `CODE_SIGNING_ALLOWED=NO`.
 

--- a/VISION.md
+++ b/VISION.md
@@ -38,6 +38,8 @@ Priority:
 - Keep dark and light controller hierarchy rendering covered by hosted XCTest
 - Keep loaded-controller dark-to-light and light-to-dark rendering covered by
   hosted XCTest
+- Keep tvOS simulator destination identifiers non-empty and validated before
+  invoking `xcodebuild`
 - Keep focused tvOS 17 trait registration with a tvOS 12 through 16 fallback
 - Keep Reduce Motion behavior animation-free and retain maximum-contrast color pairs
 - Keep completed maintenance plans under `docs/plans`

--- a/docs/plans/2026-06-25-tvos-simulator-udid-validation-design.md
+++ b/docs/plans/2026-06-25-tvos-simulator-udid-validation-design.md
@@ -1,0 +1,33 @@
+# tvOS Simulator UDID Validation Design
+
+Status: Completed
+
+## Problem
+
+The hosted XCTest destination selector trusts the `udid` field from `simctl`
+and the output of `simctl create`. A missing or blank value produces
+`platform=tvOS Simulator,id=` and defers the failure to `xcodebuild`, where the
+result is less specific and harder to diagnose.
+
+## Options Considered
+
+1. Validate only in the workflow shell. This duplicates selector policy and
+   leaves direct callers unsafe.
+2. Require a UUID-shaped identifier. This is stricter than the selector needs
+   and could reject future valid simulator identifier formats.
+3. Accept only non-empty string identifiers in the selector. Skip malformed
+   existing devices and reject malformed creation output immediately.
+
+## Decision
+
+Use one helper that trims and validates non-empty string UDIDs. Existing devices
+without a usable identifier are ignored so the selector can create the reviewed
+device type. Empty creation output raises a stable `RuntimeError` before any
+destination string is emitted.
+
+## Verification
+
+Portable unit tests cover blank existing and created identifiers. Static
+contracts preserve the helper and hostile cases, while hosted macOS continues
+to exercise the real `simctl` and `xcodebuild` path. The completed change must
+pass `make check` before merge.

--- a/docs/plans/2026-06-25-tvos-simulator-udid-validation.md
+++ b/docs/plans/2026-06-25-tvos-simulator-udid-validation.md
@@ -1,0 +1,30 @@
+# tvOS Simulator UDID Validation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+Status: Completed
+
+**Goal:** Prevent the tvOS destination selector from emitting blank simulator identifiers.
+
+**Architecture:** Keep simulator discovery and creation unchanged, but route both existing-device and creation results through one non-empty string validator before constructing the destination.
+
+**Tech Stack:** Python 3.12, `xcrun simctl`, `unittest`, repository static contracts.
+
+---
+
+## Tasks
+
+1. Add failing tests for blank existing and created UDIDs.
+2. Add a shared normalized-UDID helper.
+3. Skip malformed existing devices and reject malformed creation output.
+4. Add static and documentation contracts.
+5. Run portable, mutation, hosted, and review gates.
+
+## Verification Completed
+
+- The focused blank-ID unit tests failed before implementation; the completed
+  matrix also covers non-string discovered and created identifiers.
+- `make check` runs the portable selector suite and static contracts.
+- A hostile mutation that returned blank normalized identifiers was rejected by
+  both focused regressions.
+- Hosted macOS XCTest remains the real `simctl` and destination integration gate.

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -691,13 +691,19 @@ def check_ci_baseline_docs():
         'DEVICE_NAME = "Apple TV 4K (3rd generation)"',
         '["xcrun", "simctl", "list", "--json"]',
         '["xcrun", "simctl", "create", name, device_type, runtime]',
-        'return f"platform=tvOS Simulator,id={device[\'udid\']}"',
+        "def normalize_udid(value):",
+        'udid = normalize_udid(device.get("udid"))',
+        'raise RuntimeError("created simulator returned no UDID")',
+        'return f"platform=tvOS Simulator,id={udid}"',
         'raise RuntimeError("no available tvOS simulator runtime is installed")',
     ):
         require(fragment in selector, f"simulator selector is missing: {fragment}")
     for test_name in (
         "test_uses_matching_device_from_newest_available_runtime",
         "test_creates_matching_device_when_runtime_has_no_device",
+        "test_ignores_matching_device_with_blank_udid_and_creates_replacement",
+        "test_ignores_matching_device_with_non_string_udid",
+        "test_rejects_invalid_created_device_udid",
         "test_rejects_missing_available_tvos_runtime",
     ):
         require(test_name in selector_tests, f"simulator selector test is missing: {test_name}")

--- a/scripts/select_tvos_destination.py
+++ b/scripts/select_tvos_destination.py
@@ -15,6 +15,13 @@ def version_key(version):
     return tuple(int(component) for component in re.findall(r"\d+", version))
 
 
+def normalize_udid(value):
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
 def select_destination(payload, create_device):
     runtimes = [
         runtime
@@ -30,7 +37,9 @@ def select_destination(payload, create_device):
     devices = payload.get("devices", {}).get(runtime_identifier, [])
     for device in devices:
         if device.get("name") == DEVICE_NAME and device.get("isAvailable", True):
-            return f"platform=tvOS Simulator,id={device['udid']}"
+            udid = normalize_udid(device.get("udid"))
+            if udid is not None:
+                return f"platform=tvOS Simulator,id={udid}"
 
     device_type = next(
         (
@@ -43,7 +52,11 @@ def select_destination(payload, create_device):
     if device_type is None:
         raise RuntimeError(f"simulator device type is unavailable: {DEVICE_NAME}")
 
-    udid = create_device(CREATED_DEVICE_NAME, device_type, runtime_identifier)
+    udid = normalize_udid(
+        create_device(CREATED_DEVICE_NAME, device_type, runtime_identifier)
+    )
+    if udid is None:
+        raise RuntimeError("created simulator returned no UDID")
     return f"platform=tvOS Simulator,id={udid}"
 
 

--- a/tests/test_select_tvos_destination.py
+++ b/tests/test_select_tvos_destination.py
@@ -82,6 +82,97 @@ class SelectTVOSDestinationTests(unittest.TestCase):
             ],
         )
 
+    def test_ignores_matching_device_with_blank_udid_and_creates_replacement(self):
+        payload = {
+            "devices": {
+                "com.apple.CoreSimulator.SimRuntime.tvOS-18-5": [
+                    {
+                        "name": "Apple TV 4K (3rd generation)",
+                        "udid": "  ",
+                        "isAvailable": True,
+                    }
+                ],
+            },
+            "runtimes": [
+                {
+                    "identifier": "com.apple.CoreSimulator.SimRuntime.tvOS-18-5",
+                    "version": "18.5",
+                    "isAvailable": True,
+                }
+            ],
+            "devicetypes": [
+                {
+                    "name": "Apple TV 4K (3rd generation)",
+                    "identifier": "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K",
+                }
+            ],
+        }
+
+        destination = select_destination(
+            payload,
+            create_device=lambda *_: "REPLACEMENT",
+        )
+
+        self.assertEqual(destination, "platform=tvOS Simulator,id=REPLACEMENT")
+
+    def test_ignores_matching_device_with_non_string_udid(self):
+        payload = {
+            "devices": {
+                "com.apple.CoreSimulator.SimRuntime.tvOS-18-5": [
+                    {
+                        "name": "Apple TV 4K (3rd generation)",
+                        "udid": 123,
+                        "isAvailable": True,
+                    }
+                ],
+            },
+            "runtimes": [
+                {
+                    "identifier": "com.apple.CoreSimulator.SimRuntime.tvOS-18-5",
+                    "version": "18.5",
+                    "isAvailable": True,
+                }
+            ],
+            "devicetypes": [
+                {
+                    "name": "Apple TV 4K (3rd generation)",
+                    "identifier": "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K",
+                }
+            ],
+        }
+
+        destination = select_destination(
+            payload,
+            create_device=lambda *_: "REPLACEMENT",
+        )
+
+        self.assertEqual(destination, "platform=tvOS Simulator,id=REPLACEMENT")
+
+    def test_rejects_invalid_created_device_udid(self):
+        payload = {
+            "devices": {
+                "com.apple.CoreSimulator.SimRuntime.tvOS-18-5": [],
+            },
+            "runtimes": [
+                {
+                    "identifier": "com.apple.CoreSimulator.SimRuntime.tvOS-18-5",
+                    "version": "18.5",
+                    "isAvailable": True,
+                }
+            ],
+            "devicetypes": [
+                {
+                    "name": "Apple TV 4K (3rd generation)",
+                    "identifier": "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K",
+                }
+            ],
+        }
+
+        for invalid_udid in (" \n", 123):
+            with self.subTest(invalid_udid=invalid_udid):
+                with self.assertRaisesRegex(RuntimeError, "created simulator returned no UDID"):
+                    select_destination(payload, create_device=lambda *_: invalid_udid)
+
     def test_rejects_missing_available_tvos_runtime(self):
         payload = {
             "devices": {},


### PR DESCRIPTION
## Summary
- normalize discovered and newly created tvOS simulator UDIDs before constructing the XCTest destination
- skip matching devices with missing, non-string, or blank identifiers

## Baseline
- malformed or blank simulator identifiers could flow into destination construction or leave selector failures dependent on incidental output shape

## Improvements
- fail with a stable selector error when `simctl create` returns no usable identifier
- add portable regressions plus static and documentation contracts

## Validation
- both blank-ID regressions failed before implementation
- six portable selector tests, tvOS static contracts, and Make verification passed
- hosted static contracts, Xcode/tvOS XCTest destination use, and CodeQL analysis passed
- the hostile normalization mutation was rejected by both blank-ID regressions

## Risk
- local Linux validation has no Xcode or tvOS simulator; native destination behavior depends on the hosted macOS lane

## Follow-Ups
- preserve non-string, blank, and missing-identifier rejection as simulator discovery output evolves
