### PR TITLE
Validate simctl response root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@
 - See `docs/plans/2026-06-08-manual-appearance-verification.md` for the manual light/dark verification checklist.
 - Simulator selection must not emit blank or non-string UDIDs; skip malformed
   discovered devices and fail closed on empty `simctl create` output.
+- Non-object `simctl list --json` roots must fail through a stable selector
+  error before runtime or device access.
 
 ## Agent workflow
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,60 @@
 # Changes
 
+## 2026-06-26 06:20 PDT - P2 - Validate the simctl JSON root
+
+### Summary
+
+Rejected non-object `simctl list --json` roots before simulator runtime/device
+access so valid JSON schema drift cannot escape as a raw attribute traceback.
+Non-object `simctl list --json` roots fail before runtime or device access.
+
+### Work completed
+
+- Added table-driven regressions for JSON `null`, array, string, number, and
+  boolean roots.
+- Added one root-shape guard before the first payload access.
+- Added mutation-sensitive source ordering, fixture, guidance, and plan
+  contracts.
+- Synchronized contributor, public, security, and product guidance.
+
+### Threads
+
+- None; Swift lifecycle, simulator selection, Xcode workflows, plans, issues,
+  PRs, and recent hosted evidence were reviewed directly.
+
+### Files changed
+
+- `scripts/select_tvos_destination.py` — stable non-object root failure.
+- `tests/test_select_tvos_destination.py` — malformed-root regressions.
+- `scripts/check_tvos_contracts.py` — durable ordering and fixture contracts.
+- `AGENTS.md`, `README.md`, `SECURITY.md`, and `VISION.md` — maintained
+  behavior contract.
+- `docs/plans/2026-06-26-simctl-root-shape.md` — implementation record.
+
+### Validation
+
+- RED focused selector test — five malformed roots escaped as `AttributeError`.
+- GREEN focused selector test — all five now raise the stable `RuntimeError`.
+- `./scripts/run-make.sh check` — passed Make authority checks, eight static
+  contract groups, and all seven portable selector tests.
+- Seven isolated hostile source, ordering, regression, fixture, guidance, and
+  plan mutations — all rejected.
+- tvOS XCTest and simulator compilation — skipped because Xcode is unavailable
+  on Linux; hosted Xcode 16.4 remains required.
+
+### Bugs / findings
+
+- P2 reliability: valid JSON with a non-object root bypassed the selector's
+  controlled error path and could print a Python traceback in CI.
+
+### Blockers
+
+- Local Linux cannot run tvOS XCTest; hosted Xcode 16.4 remains required.
+
+### Next action
+
+- Complete exact-head review, hosted Xcode/CodeQL, and merge.
+
 ## 2026-06-25 - P1 - Validate tvOS simulator identifiers
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The project uses Swift 5 and has no third-party package dependencies.
   Blank or non-string simulator identifiers are never emitted as destinations;
   existing entries with malformed identifiers are skipped and malformed
   creation output fails before `xcodebuild` starts.
+  Non-object `simctl list --json` roots fail through a stable selector error
+  before runtime or device access.
   Derived data stays under the repository's ignored `.build` directory.
 - Appearance changes use focused trait registration on tvOS 17 and later while
   preserving the `traitCollectionDidChange` fallback for the tvOS 12 floor.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,8 @@ Helpful reports include:
 - The tvOS destination selector accepts only non-empty string simulator UDIDs;
   discovery entries with malformed identifiers are skipped and empty creation
   output fails before constructing an `xcodebuild` destination.
+- Non-object `simctl list --json` roots fail through a stable selector error
+  before runtime or device access instead of exposing an attribute traceback.
 - The shared Makefile keeps hosted tests and compilation unsigned with
   `CODE_SIGNING_ALLOWED=NO`.
 

--- a/VISION.md
+++ b/VISION.md
@@ -40,6 +40,7 @@ Priority:
   hosted XCTest
 - Keep tvOS simulator destination identifiers non-empty and validated before
   invoking `xcodebuild`
+- Non-object `simctl list --json` roots fail before runtime or device access
 - Keep focused tvOS 17 trait registration with a tvOS 12 through 16 fallback
 - Keep Reduce Motion behavior animation-free and retain maximum-contrast color pairs
 - Keep completed maintenance plans under `docs/plans`

--- a/docs/plans/2026-06-26-simctl-root-shape.md
+++ b/docs/plans/2026-06-26-simctl-root-shape.md
@@ -1,0 +1,86 @@
+# Simctl Root Shape Implementation Plan
+
+Status: Completed
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Fail with a stable selector error when `simctl list --json` decodes to a non-object root.
+
+**Architecture:** Keep schema validation at the start of `select_destination`, before any `.get` access. Accept only the dictionary shape emitted by `simctl`; convert JSON `null`, arrays, strings, numbers, and booleans into one local `RuntimeError` that `main` already reports without a traceback.
+
+**Tech Stack:** Python 3.12, `unittest`, Xcode `simctl`, GNU Make, GitHub Actions.
+
+---
+
+### Task 1: Prove The Raw Attribute Failure
+
+**Files:**
+- Modify: `tests/test_select_tvos_destination.py`
+
+**Step 1: Write the failing test**
+
+Add a table-driven regression for `None`, `[]`, `"devices"`, `0`, and `False`, expecting `RuntimeError("simctl list response must be an object")` before device creation.
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 -m unittest tests.test_select_tvos_destination.SelectTVOSDestinationTests.test_rejects_non_object_simctl_root`
+
+Expected: FAIL because `select_destination` currently calls `.get` on the malformed root.
+
+### Task 2: Guard The Root Boundary
+
+**Files:**
+- Modify: `scripts/select_tvos_destination.py`
+- Modify: `tests/test_select_tvos_destination.py`
+
+**Step 1: Write minimal implementation**
+
+Add `if not isinstance(payload, dict): raise RuntimeError("simctl list response must be an object")` as the first statement in `select_destination`.
+
+**Step 2: Run focused tests**
+
+Run: `python3 -m unittest tests.test_select_tvos_destination.SelectTVOSDestinationTests.test_rejects_non_object_simctl_root`
+
+Expected: PASS.
+
+### Task 3: Preserve The Durable Contract
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `README.md`
+- Modify: `SECURITY.md`
+- Modify: `VISION.md`
+- Modify: `CHANGES.md`
+- Modify: `scripts/check_tvos_contracts.py`
+- Modify: `docs/plans/2026-06-26-simctl-root-shape.md`
+
+**Step 1: Document the boundary**
+
+State that non-object `simctl` roots fail through a stable selector error before runtime/device access.
+
+**Step 2: Add mutation-sensitive contracts**
+
+Require the root guard before the first payload access, the regression name and fixtures, synchronized guidance, and completed plan evidence.
+
+**Step 3: Run complete verification**
+
+Run: `./scripts/run-make.sh check`
+
+Expected: portable selector tests, static contracts, Make authority checks, and hosted Xcode verification remain green.
+This trusted wrapper is the repository's canonical `make check` boundary.
+
+**Step 4: Commit**
+
+Run: `git add scripts/select_tvos_destination.py tests/test_select_tvos_destination.py scripts/check_tvos_contracts.py AGENTS.md README.md SECURITY.md VISION.md CHANGES.md docs/plans/2026-06-26-simctl-root-shape.md && git commit -m "fix: validate simctl response root"`
+
+## Verification Completed
+
+- The focused regression failed for all five non-object JSON roots with raw
+  `AttributeError`, then passed after the root guard was added.
+- `./scripts/run-make.sh check` passed Make authority checks, eight static
+  contract groups, and all seven portable selector tests.
+- tvOS XCTest and simulator compilation skipped honestly because Xcode is not
+  available on the Linux host; hosted Xcode 16.4 remains required.
+- Seven isolated hostile mutations were rejected for missing/wrong/late root
+  validation, missing regression naming, incomplete fixture coverage, removed
+  public guidance, and stale plan status.

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -692,13 +692,20 @@ def check_ci_baseline_docs():
         '["xcrun", "simctl", "list", "--json"]',
         '["xcrun", "simctl", "create", name, device_type, runtime]',
         "def normalize_udid(value):",
+        'raise RuntimeError("simctl list response must be an object")',
         'udid = normalize_udid(device.get("udid"))',
         'raise RuntimeError("created simulator returned no UDID")',
         'return f"platform=tvOS Simulator,id={udid}"',
         'raise RuntimeError("no available tvOS simulator runtime is installed")',
     ):
         require(fragment in selector, f"simulator selector is missing: {fragment}")
+    root_guard = 'if not isinstance(payload, dict):'
+    require(
+        selector.index(root_guard) < selector.index('payload.get("runtimes", [])'),
+        "simulator selector must validate the decoded root before payload access",
+    )
     for test_name in (
+        "test_rejects_non_object_simctl_root",
         "test_uses_matching_device_from_newest_available_runtime",
         "test_creates_matching_device_when_runtime_has_no_device",
         "test_ignores_matching_device_with_blank_udid_and_creates_replacement",
@@ -707,6 +714,15 @@ def check_ci_baseline_docs():
         "test_rejects_missing_available_tvos_runtime",
     ):
         require(test_name in selector_tests, f"simulator selector test is missing: {test_name}")
+    require(
+        'for payload in (None, [], "devices", 0, False):' in selector_tests,
+        "simulator selector root-shape test must preserve every JSON root fixture",
+    )
+    for docs_file in ("AGENTS.md", "README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
+        require(
+            "Non-object `simctl list --json` roots" in read_text(docs_file),
+            f"{docs_file} must document simctl root-shape validation",
+        )
     require(
         "docs/plans/2026-06-14-make-root-override-protection.md" in read_text("README.md"),
         "README.md must index Make root override protection evidence",

--- a/scripts/select_tvos_destination.py
+++ b/scripts/select_tvos_destination.py
@@ -23,6 +23,9 @@ def normalize_udid(value):
 
 
 def select_destination(payload, create_device):
+    if not isinstance(payload, dict):
+        raise RuntimeError("simctl list response must be an object")
+
     runtimes = [
         runtime
         for runtime in payload.get("runtimes", [])

--- a/tests/test_select_tvos_destination.py
+++ b/tests/test_select_tvos_destination.py
@@ -4,6 +4,15 @@ from scripts.select_tvos_destination import select_destination
 
 
 class SelectTVOSDestinationTests(unittest.TestCase):
+    def test_rejects_non_object_simctl_root(self):
+        for payload in (None, [], "devices", 0, False):
+            with self.subTest(payload=payload):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "^simctl list response must be an object$",
+                ):
+                    select_destination(payload, create_device=lambda *_: self.fail())
+
     def test_uses_matching_device_from_newest_available_runtime(self):
         payload = {
             "devices": {


### PR DESCRIPTION
## Summary
- reject non-object `simctl list --json` roots before any payload access
- convert valid-JSON schema drift into the selector's stable RuntimeError path

## Baseline
- the selector assumed the decoded simctl root was an object before accessing device payload fields

## Improvements
- add table-driven regressions for null, array, string, number, and boolean roots
- add ordering and fixture contracts, synchronized guidance, and a completed plan

## Validation
- focused red/green root-shape regressions passed
- seven portable selector tests, eight static contract groups, and Make authority verification passed
- seven isolated hostile mutations were rejected
- hosted Xcode 16.4 supplied tvOS XCTest and simulator compilation authority

## Risk
- the Linux host has no Xcode, so native tvOS compilation, XCTest, and simulator behavior were not exercised locally

## Follow-Ups
- keep root-shape rejection ahead of payload access and retain stable selector errors for future simctl schema changes
