### PR TITLE
fix: validate simctl collection shapes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@
   discovered devices and fail closed on empty `simctl create` output.
 - Non-object `simctl list --json` roots must fail through a stable selector
   error before runtime or device access.
+- Malformed `simctl` runtime, device, and device-type collections must fail
+  through stable selector errors before iteration.
 
 ## Agent workflow
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,69 @@
 # Changes
 
+## 2026-06-26 14:23 PDT - P2 - Validate simctl collection shapes
+
+### Summary
+
+Rejected malformed `simctl` runtime, device, and device-type collections before
+iteration so valid JSON schema drift cannot escape as raw Python type or
+attribute tracebacks.
+Malformed `simctl` runtime, device, and device-type collections now fail
+through stable selector errors before iteration.
+
+### Work completed
+
+- Added table-driven regressions for null and scalar collection containers and
+  entries.
+- Added narrow object-map and object-array validators at each traversed
+  collection boundary.
+- Added mutation-sensitive source, fixture, guidance, and plan contracts.
+- Synchronized contributor, public, security, and product guidance.
+
+### Threads
+
+- None; open PRs, issues, alerts, branches, plans, recent changes, simulator
+  selection, Make authority, and hosted workflow evidence were reviewed
+  directly.
+
+### Files changed
+
+- `scripts/select_tvos_destination.py` — stable nested collection failures.
+- `tests/test_select_tvos_destination.py` — malformed collection regressions.
+- `scripts/check_tvos_contracts.py` — durable source and fixture contracts.
+- `AGENTS.md`, `README.md`, `SECURITY.md`, and `VISION.md` — maintained
+  behavior contract.
+- `docs/plans/2026-06-26-simctl-collection-shape-design.md` — design record.
+- `docs/plans/2026-06-26-simctl-collection-shape.md` — implementation record.
+
+### Validation
+
+- RED focused selector test — six malformed collections escaped as raw
+  `TypeError` or `AttributeError` failures.
+- GREEN focused selector test — all six now raise stable `RuntimeError`
+  messages and all eight portable selector tests pass.
+- `./scripts/run-make.sh check` — passed Make authority checks, eight static
+  contract groups, and all eight portable selector tests.
+- Seven isolated hostile source, error-message, regression, fixture, guidance,
+  and plan mutations — all rejected.
+- Python compileall, diff whitespace validation, and current-tree gitleaks —
+  passed with no findings.
+- tvOS XCTest and simulator compilation — expected to skip because Xcode is
+  unavailable on Linux; hosted Xcode 16.4 remains required.
+
+### Bugs / findings
+
+- P2 reliability: valid JSON with malformed nested collection shapes bypassed
+  the selector's controlled error path and could print a Python traceback in
+  CI.
+
+### Blockers
+
+- Local Linux cannot run tvOS XCTest; hosted Xcode 16.4 remains required.
+
+### Next action
+
+- Complete exact-head review, hosted Xcode/CodeQL, and merge.
+
 ## 2026-06-26 06:20 PDT - P2 - Validate the simctl JSON root
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ The project uses Swift 5 and has no third-party package dependencies.
   creation output fails before `xcodebuild` starts.
   Non-object `simctl list --json` roots fail through a stable selector error
   before runtime or device access.
+  Malformed `simctl` runtime, device, and device-type collections also fail
+  through stable selector errors before iteration instead of exposing Python
+  tracebacks.
   Derived data stays under the repository's ignored `.build` directory.
 - Appearance changes use focused trait registration on tvOS 17 and later while
   preserving the `traitCollectionDidChange` fallback for the tvOS 12 floor.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,9 @@ Helpful reports include:
   output fails before constructing an `xcodebuild` destination.
 - Non-object `simctl list --json` roots fail through a stable selector error
   before runtime or device access instead of exposing an attribute traceback.
+- Malformed `simctl` runtime, device, and device-type collections fail through
+  stable selector errors before iteration instead of exposing type or
+  attribute tracebacks.
 - The shared Makefile keeps hosted tests and compilation unsigned with
   `CODE_SIGNING_ALLOWED=NO`.
 

--- a/VISION.md
+++ b/VISION.md
@@ -41,6 +41,8 @@ Priority:
 - Keep tvOS simulator destination identifiers non-empty and validated before
   invoking `xcodebuild`
 - Non-object `simctl list --json` roots fail before runtime or device access
+- Malformed `simctl` runtime, device, and device-type collections fail before
+  iteration
 - Keep focused tvOS 17 trait registration with a tvOS 12 through 16 fallback
 - Keep Reduce Motion behavior animation-free and retain maximum-contrast color pairs
 - Keep completed maintenance plans under `docs/plans`

--- a/docs/plans/2026-06-26-simctl-collection-shape-design.md
+++ b/docs/plans/2026-06-26-simctl-collection-shape-design.md
@@ -1,0 +1,35 @@
+# Simctl Collection Shape Design
+
+Status: Completed
+
+## Problem
+
+The selector validates the decoded JSON root, but it still assumes that the
+`runtimes`, `devices`, and `devicetypes` members have the collection shapes
+emitted by `simctl`. Valid JSON schema drift such as `null`, scalar entries, or
+a non-object devices map escapes as `TypeError` or `AttributeError`, which
+`main` does not classify as a controlled selector failure.
+
+## Options Considered
+
+1. Catch `TypeError` and `AttributeError` in `main`. This hides programming
+   mistakes anywhere in the selector and reports them as upstream data errors.
+2. Fully model every `simctl` field. This is unnecessary for choosing a
+   destination and would tightly couple the sample to undocumented fields.
+3. Validate only the collection boundaries traversed by the selector. Require
+   object entries in the relevant arrays and an object devices map, while
+   preserving the existing permissive handling of optional scalar fields.
+
+## Decision
+
+Use small local validators for arrays of objects and object maps. Validate each
+collection immediately before traversal so malformed nested structures raise a
+stable `RuntimeError` without broad exception catching or behavior changes for
+valid `simctl` payloads.
+
+## Verification
+
+Portable unit tests cover malformed containers and entries for runtimes,
+devices, and device types. Static contracts preserve the validators, failure
+messages, fixtures, guidance, and implementation plan. The completed change
+must pass `make check` before merge.

--- a/docs/plans/2026-06-26-simctl-collection-shape.md
+++ b/docs/plans/2026-06-26-simctl-collection-shape.md
@@ -1,0 +1,65 @@
+# Simctl Collection Shape Implementation Plan
+
+Status: Completed
+
+**Goal:** Fail with stable selector errors when traversed `simctl list --json`
+collections are malformed.
+
+**Architecture:** Add narrow collection validators inside the selector module.
+Validate the runtime and device-type arrays, the devices object, and the chosen
+runtime's device array before iteration. Do not broaden `main` exception
+handling or validate unrelated `simctl` fields.
+
+**Tech Stack:** Python 3, `unittest`, Xcode `simctl`, GNU Make, GitHub Actions.
+
+---
+
+### Task 1: Prove Nested Shape Failures
+
+**Files:**
+- Modify: `tests/test_select_tvos_destination.py`
+
+1. Add table-driven malformed container and entry regressions.
+2. Run the focused test and confirm raw `TypeError` or `AttributeError` errors.
+
+### Task 2: Validate Traversed Collections
+
+**Files:**
+- Modify: `scripts/select_tvos_destination.py`
+- Modify: `tests/test_select_tvos_destination.py`
+
+1. Add minimal object-map and object-array validators.
+2. Apply them immediately before each collection is traversed.
+3. Run focused and complete portable selector tests.
+
+### Task 3: Preserve The Contract
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `README.md`
+- Modify: `SECURITY.md`
+- Modify: `VISION.md`
+- Modify: `CHANGES.md`
+- Modify: `scripts/check_tvos_contracts.py`
+- Modify: `docs/plans/2026-06-26-simctl-collection-shape.md`
+
+1. Document stable nested collection failures.
+2. Add mutation-sensitive source, regression, fixture, guidance, and plan
+   contracts.
+3. Run `./scripts/run-make.sh check` and record platform skips honestly.
+4. Validate hostile mutations, scan the current tree, and push a focused PR.
+
+## Verification Completed
+
+- The focused regression reproduced six raw `TypeError` or `AttributeError`
+  failures, then passed after collection validation was added.
+- All eight portable selector tests passed.
+- `./scripts/run-make.sh check` passed Make authority checks, static contracts,
+  and portable tests; tvOS XCTest and compilation skipped because Xcode is not
+  available on this Linux host.
+- This is the repository's trusted `make check` verification path.
+- Seven isolated hostile mutations were rejected for missing runtime/device
+  validation, changed failure messages, removed regression/fixture coverage,
+  stale public guidance, and incomplete plan status.
+- Python compileall, diff whitespace validation, and current-tree gitleaks
+  completed without findings.

--- a/scripts/check_tvos_contracts.py
+++ b/scripts/check_tvos_contracts.py
@@ -692,7 +692,15 @@ def check_ci_baseline_docs():
         '["xcrun", "simctl", "list", "--json"]',
         '["xcrun", "simctl", "create", name, device_type, runtime]',
         "def normalize_udid(value):",
+        "def require_object(value, label):",
+        "def require_object_list(value, label):",
         'raise RuntimeError("simctl list response must be an object")',
+        'raise RuntimeError(f"simctl list {label} must be an object")',
+        'raise RuntimeError(f"simctl list {label} must be an array of objects")',
+        'require_object_list(payload.get("runtimes", []), "runtimes")',
+        'require_object(payload.get("devices", {}), "devices")',
+        '"devices for selected runtime"',
+        'payload.get("devicetypes", [])',
         'udid = normalize_udid(device.get("udid"))',
         'raise RuntimeError("created simulator returned no UDID")',
         'return f"platform=tvOS Simulator,id={udid}"',
@@ -706,6 +714,7 @@ def check_ci_baseline_docs():
     )
     for test_name in (
         "test_rejects_non_object_simctl_root",
+        "test_rejects_malformed_simctl_collections",
         "test_uses_matching_device_from_newest_available_runtime",
         "test_creates_matching_device_when_runtime_has_no_device",
         "test_ignores_matching_device_with_blank_udid_and_creates_replacement",
@@ -718,10 +727,26 @@ def check_ci_baseline_docs():
         'for payload in (None, [], "devices", 0, False):' in selector_tests,
         "simulator selector root-shape test must preserve every JSON root fixture",
     )
+    for fixture in (
+        '{"runtimes": None}',
+        '{"runtimes": [1]}',
+        '"devices": None',
+        '"devicetypes": None',
+        '"devicetypes": [1]',
+    ):
+        require(
+            fixture in selector_tests,
+            f"simulator selector collection-shape test is missing fixture: {fixture}",
+        )
     for docs_file in ("AGENTS.md", "README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
         require(
             "Non-object `simctl list --json` roots" in read_text(docs_file),
             f"{docs_file} must document simctl root-shape validation",
+        )
+        require(
+            "Malformed `simctl` runtime, device, and device-type collections"
+            in read_text(docs_file),
+            f"{docs_file} must document simctl collection-shape validation",
         )
     require(
         "docs/plans/2026-06-14-make-root-override-protection.md" in read_text("README.md"),

--- a/scripts/select_tvos_destination.py
+++ b/scripts/select_tvos_destination.py
@@ -22,13 +22,27 @@ def normalize_udid(value):
     return normalized or None
 
 
+def require_object(value, label):
+    if not isinstance(value, dict):
+        raise RuntimeError(f"simctl list {label} must be an object")
+    return value
+
+
+def require_object_list(value, label):
+    if not isinstance(value, list) or any(
+        not isinstance(item, dict) for item in value
+    ):
+        raise RuntimeError(f"simctl list {label} must be an array of objects")
+    return value
+
+
 def select_destination(payload, create_device):
     if not isinstance(payload, dict):
         raise RuntimeError("simctl list response must be an object")
 
     runtimes = [
         runtime
-        for runtime in payload.get("runtimes", [])
+        for runtime in require_object_list(payload.get("runtimes", []), "runtimes")
         if ".tvOS-" in runtime.get("identifier", "")
         and runtime.get("isAvailable", True)
     ]
@@ -37,7 +51,11 @@ def select_destination(payload, create_device):
 
     runtime = max(runtimes, key=lambda item: version_key(item.get("version", "0")))
     runtime_identifier = runtime["identifier"]
-    devices = payload.get("devices", {}).get(runtime_identifier, [])
+    devices_by_runtime = require_object(payload.get("devices", {}), "devices")
+    devices = require_object_list(
+        devices_by_runtime.get(runtime_identifier, []),
+        "devices for selected runtime",
+    )
     for device in devices:
         if device.get("name") == DEVICE_NAME and device.get("isAvailable", True):
             udid = normalize_udid(device.get("udid"))
@@ -47,7 +65,10 @@ def select_destination(payload, create_device):
     device_type = next(
         (
             item["identifier"]
-            for item in payload.get("devicetypes", [])
+            for item in require_object_list(
+                payload.get("devicetypes", []),
+                "devicetypes",
+            )
             if item.get("name") == DEVICE_NAME
         ),
         None,

--- a/tests/test_select_tvos_destination.py
+++ b/tests/test_select_tvos_destination.py
@@ -13,6 +13,55 @@ class SelectTVOSDestinationTests(unittest.TestCase):
                 ):
                     select_destination(payload, create_device=lambda *_: self.fail())
 
+    def test_rejects_malformed_simctl_collections(self):
+        runtime = {
+            "identifier": "com.apple.CoreSimulator.SimRuntime.tvOS-18-5",
+            "version": "18.5",
+            "isAvailable": True,
+        }
+        cases = (
+            (
+                {"runtimes": None},
+                "simctl list runtimes must be an array of objects",
+            ),
+            (
+                {"runtimes": [1]},
+                "simctl list runtimes must be an array of objects",
+            ),
+            (
+                {"runtimes": [runtime], "devices": None},
+                "simctl list devices must be an object",
+            ),
+            (
+                {
+                    "runtimes": [runtime],
+                    "devices": {runtime["identifier"]: [1]},
+                },
+                "simctl list devices for selected runtime must be an array of objects",
+            ),
+            (
+                {
+                    "runtimes": [runtime],
+                    "devices": {runtime["identifier"]: []},
+                    "devicetypes": None,
+                },
+                "simctl list devicetypes must be an array of objects",
+            ),
+            (
+                {
+                    "runtimes": [runtime],
+                    "devices": {runtime["identifier"]: []},
+                    "devicetypes": [1],
+                },
+                "simctl list devicetypes must be an array of objects",
+            ),
+        )
+
+        for payload, message in cases:
+            with self.subTest(payload=payload):
+                with self.assertRaisesRegex(RuntimeError, f"^{message}$"):
+                    select_destination(payload, create_device=lambda *_: self.fail())
+
     def test_uses_matching_device_from_newest_available_runtime(self):
         payload = {
             "devices": {


### PR DESCRIPTION
## Summary
- reject malformed runtime, device, and device-type collections before traversal
- preserve valid simulator selection and existing UDID behavior
- add portable regressions plus durable documentation and mutation-sensitive contracts

## Validation
- `./scripts/run-make.sh check`
- focused RED/GREEN selector regression
- seven hostile contract mutations rejected
- `python3 -m compileall -q scripts tests`
- `gitleaks detect --no-git --redact --source .`
- `git diff --check`

## Platform note
- tvOS XCTest and simulator compilation skip locally because Xcode is unavailable on Linux; hosted Xcode 16.4 remains required.
